### PR TITLE
fix: include task directives in diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    continue-on-error: true
     strategy:
+      fail-fast: false
       matrix:
         python-version: ['3.10', '3.11', '3.12']
 
@@ -30,7 +30,7 @@ jobs:
 
     - name: Run tests
       run: |
-        pytest tests/ -v --cov=src --cov-report=xml || echo "Tests need attention"
+        pytest
 
     - name: Upload coverage
       uses: codecov/codecov-action@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 license = {text = "MIT"}
 requires-python = ">=3.9"
 dependencies = [
-    "pygls>=1.2.0",
+    "pygls>=1.2.0,<2.0.0",
     "lsprotocol>=2023.0.0",
 ]
 

--- a/src/nwchem_lsp/parser/nwchem_parser.py
+++ b/src/nwchem_lsp/parser/nwchem_parser.py
@@ -305,6 +305,19 @@ def _add_compat_methods() -> None:
                 if not hasattr(section, "name"):
                     section.name = section_name
                 blocks.append(section)
+
+        for index, line in enumerate(self.lines):
+            parts = line.strip().lower().split()
+            if parts and parts[0] == "task":
+                task = NWchemSection(
+                    name="task",
+                    start_line=index,
+                    end_line=index,
+                    keywords=parts[1:],
+                    content=[line],
+                )
+                task.line_start = index + 1
+                blocks.append(task)
         return blocks
 
     def validate(self: Any) -> list[dict[str, Any]]:

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,45 @@
+"""Tests for NWChem diagnostics."""
+
+from nwchem_lsp.features.diagnostic import DiagnosticProvider
+
+
+def test_task_directive_satisfies_required_task_check() -> None:
+    """Top-level task directives should not be reported as missing."""
+    source = """geometry
+  H 0.0 0.0 0.0
+end
+
+basis
+  H library sto-3g
+end
+
+task scf energy
+"""
+    provider = DiagnosticProvider(None)
+
+    diagnostics = provider.get_diagnostics(source)
+
+    messages = [diagnostic.message for diagnostic in diagnostics]
+    assert "Missing required 'task' directive" not in messages
+
+
+def test_task_directive_operation_is_validated() -> None:
+    """Top-level task directives should still be checked for bad operations."""
+    source = """geometry
+  H 0.0 0.0 0.0
+end
+
+basis
+  H library sto-3g
+end
+
+task scf not_an_operation
+"""
+    provider = DiagnosticProvider(None)
+
+    diagnostics = provider.get_diagnostics(source)
+
+    assert any(
+        diagnostic.message == "Unknown task operation: 'not_an_operation'"
+        for diagnostic in diagnostics
+    )


### PR DESCRIPTION
## Summary
- treat top-level `task` directives as satisfying required-task diagnostics
- keep invalid task operations covered by diagnostics
- cap `pygls` below 2.0 because the server and feature modules use the pygls 1.x `LanguageServer` API
- make CI fail on real test failures instead of masking them with `continue-on-error` / `|| echo`

Closes #24
Closes #27
Closes #29

## Validation
- `uv run --with pytest --with pytest-cov python -m pytest` — 188 passed, 1 warning
