### PR TITLE
refactor: Unify diagnostic providers and fix naming conventions

### DIFF
--- a/src/nwchem_lsp/features/__init__.py
+++ b/src/nwchem_lsp/features/__init__.py
@@ -1,7 +1,7 @@
 """LSP features for NWChem."""
 
 from .completion import NwchemCompletionProvider
-from .diagnostic import DiagnosticProvider
+from .diagnostic import NwchemDiagnosticProvider
 from .formatting import NwchemFormattingProvider
 from .hover import NwchemHoverProvider
 from .symbols import NwchemSymbolProvider
@@ -9,7 +9,7 @@ from .symbols import NwchemSymbolProvider
 __all__ = [
     "NwchemCompletionProvider",
     "NwchemHoverProvider",
-    "DiagnosticProvider",
+    "NwchemDiagnosticProvider",
     "NwchemSymbolProvider",
     "NwchemFormattingProvider",
 ]

--- a/src/nwchem_lsp/features/completion.py
+++ b/src/nwchem_lsp/features/completion.py
@@ -18,7 +18,6 @@ from ..data.keywords import (
     BASIS_SETS,
     DFT_FUNCTIONALS,
     DFT_KEYWORDS,
-    ELEMENTS,
     GEOMETRY_KEYWORDS,
     SCF_KEYWORDS,
     TASK_OPERATIONS,
@@ -206,30 +205,6 @@ class NwchemCompletionProvider:
                 label=operation,
                 kind=CompletionItemKind.EnumMember,
                 detail=f"Task: {operation}",
-            )
-            items.append(item)
-
-        return items
-
-    def _get_element_completions(self, prefix: str = "") -> List[CompletionItem]:
-        """Get chemical element completions.
-
-        Args:
-            prefix: Current word prefix
-
-        Returns:
-            List of completion items
-        """
-        items: List[CompletionItem] = []
-
-        for element in ELEMENTS:
-            if prefix and not element.lower().startswith(prefix.lower()):
-                continue
-
-            item = CompletionItem(
-                label=element,
-                kind=CompletionItemKind.Constant,
-                detail=f"Element: {element}",
             )
             items.append(item)
 

--- a/src/nwchem_lsp/features/diagnostic.py
+++ b/src/nwchem_lsp/features/diagnostic.py
@@ -16,7 +16,7 @@ from ..parser.nwchem_parser import NwchemParser as NWChemParser
 from ..parser.nwchem_parser import NWchemSection
 
 
-class DiagnosticProvider:
+class NwchemDiagnosticProvider:
     """Provider for NWChem diagnostics."""
 
     # Valid basis sets
@@ -395,4 +395,4 @@ class DiagnosticProvider:
                         )
 
 
-__all__ = ["DiagnosticProvider"]
+__all__ = ["NwchemDiagnosticProvider"]

--- a/src/nwchem_lsp/server.py
+++ b/src/nwchem_lsp/server.py
@@ -48,7 +48,7 @@ from .features.code_actions import CodeActionsProvider
 from .features.completion import NwchemCompletionProvider
 from .features.config import ConfigProvider, get_config_provider
 from .features.definition import DefinitionProvider, get_definition_provider
-from .features.diagnostic import DiagnosticProvider
+from .features.diagnostic import NwchemDiagnosticProvider
 from .features.folding_range import FoldingRangeProvider, get_folding_range_provider
 from .features.formatting import NwchemFormattingProvider
 from .features.hover import NwchemHoverProvider
@@ -70,7 +70,7 @@ class NWChemLanguageServer(LanguageServer):
         # Initialize feature providers
         self.completion_provider = NwchemCompletionProvider(self)
         self.hover_provider = NwchemHoverProvider(self)
-        self.diagnostic_provider = DiagnosticProvider(self)
+        self.diagnostic_provider = NwchemDiagnosticProvider(self)
         self.symbol_provider = NwchemSymbolProvider(self)
         self.formatting_provider = NwchemFormattingProvider(self)
         self.code_actions_provider = CodeActionsProvider()

--- a/tests/features/test_diagnostic.py
+++ b/tests/features/test_diagnostic.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from nwchem_lsp.features.diagnostic import DiagnosticProvider
+from nwchem_lsp.features.diagnostic import NwchemDiagnosticProvider
 
 
 @pytest.fixture
@@ -11,11 +11,11 @@ def diagnostic_provider():
     from pygls.server import LanguageServer
 
     server = LanguageServer("test", "1.0")
-    return DiagnosticProvider(server)
+    return NwchemDiagnosticProvider(server)
 
 
-class TestDiagnosticProvider:
-    """Tests for DiagnosticProvider."""
+class TestNwchemDiagnosticProvider:
+    """Tests for NwchemDiagnosticProvider."""
 
     def test_provider_exists(self, diagnostic_provider):
         """Test that provider can be created."""

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,6 +1,6 @@
 """Tests for NWChem diagnostics."""
 
-from nwchem_lsp.features.diagnostic import DiagnosticProvider
+from nwchem_lsp.features.diagnostic import NwchemDiagnosticProvider
 
 
 def test_task_directive_satisfies_required_task_check() -> None:
@@ -15,7 +15,7 @@ end
 
 task scf energy
 """
-    provider = DiagnosticProvider(None)
+    provider = NwchemDiagnosticProvider(None)
 
     diagnostics = provider.get_diagnostics(source)
 
@@ -35,7 +35,7 @@ end
 
 task scf not_an_operation
 """
-    provider = DiagnosticProvider(None)
+    provider = NwchemDiagnosticProvider(None)
 
     diagnostics = provider.get_diagnostics(source)
 


### PR DESCRIPTION
Closes #17

- Renamed `DiagnosticProvider` to `NwchemDiagnosticProvider` for consistent naming with other providers (`NwchemCompletionProvider`, `NwchemHoverProvider`)
- Removed dead code: `_get_element_completions()` from `completion.py` (never called)
- Removed unused `ELEMENTS` import from `completion.py`
- Updated all imports and references across 6 files

Note: `diagnostics.py` (the orphan file) was already absent from the codebase. The `parse()` and `validate()` methods were already defined inline in the `NwchemParser` class body (no `_add_compat_methods` injection present).

All 183 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)