### PR TITLE
fix: Add comprehensive error handling throughout LSP server

### DIFF
--- a/src/nwchem_lsp/exceptions.py
+++ b/src/nwchem_lsp/exceptions.py
@@ -14,8 +14,14 @@ class NWChemLSPError(Exception):
 class ParseError(NWChemLSPError):
     """Raised when parsing NWChem input fails."""
 
-    def __init__(self, message: str = "Failed to parse NWChem input", line: int | None = None) -> None:
+    def __init__(
+        self,
+        message: str = "Failed to parse NWChem input",
+        line: int | None = None,
+        column: int | None = None,
+    ) -> None:
         self.line = line
+        self.column = column
         super().__init__(message)
 
 

--- a/src/nwchem_lsp/features/completion.py
+++ b/src/nwchem_lsp/features/completion.py
@@ -4,6 +4,7 @@ This module provides keyword completions based on the current context
 in an NWChem input file.
 """
 
+import logging
 from typing import Any, List, Optional
 
 from lsprotocol.types import (
@@ -27,6 +28,8 @@ from ..data.keywords import (
     get_keywords_by_section,
 )
 from ..parser.nwchem_parser import NwchemParser
+
+logger = logging.getLogger(__name__)
 
 
 class NwchemCompletionProvider:
@@ -55,8 +58,12 @@ class NwchemCompletionProvider:
         column = position.character
 
         # Parse the source to get context
-        parser = NwchemParser(source)
-        context = parser.get_completion_context(line_number, column)
+        try:
+            parser = NwchemParser(source)
+            context = parser.get_completion_context(line_number, column)
+        except Exception:
+            logger.exception("Error parsing source for completions")
+            return []
 
         completion_type = context.get("type", "top_level")
         current_word = context.get("word", "")

--- a/src/nwchem_lsp/features/diagnostic.py
+++ b/src/nwchem_lsp/features/diagnostic.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 from lsprotocol.types import (
     Diagnostic,
     DiagnosticSeverity,
@@ -14,6 +16,8 @@ from ..data.keywords import ALL_KEYWORDS, get_keyword
 from ..exceptions import ParseError, ValidationError
 from ..parser.nwchem_parser import NwchemParser as NWChemParser
 from ..parser.nwchem_parser import NWchemSection
+
+logger = logging.getLogger(__name__)
 
 
 class DiagnosticProvider:
@@ -110,6 +114,7 @@ class DiagnosticProvider:
             parser = NWChemParser(text)
             blocks = parser.parse()
         except (ParseError, ValidationError) as exc:
+            logger.warning("Parse/validation error in diagnostics: %s", exc)
             diagnostics.append(
                 Diagnostic(
                     range=Range(
@@ -122,6 +127,7 @@ class DiagnosticProvider:
             )
             return diagnostics
         except Exception as exc:
+            logger.exception("Unexpected error during parsing in diagnostics")
             diagnostics.append(
                 Diagnostic(
                     range=Range(
@@ -141,7 +147,14 @@ class DiagnosticProvider:
 
         # Check each block
         for block in blocks:
-            self._check_block(block, lines, diagnostics)
+            try:
+                self._check_block(block, lines, diagnostics)
+            except Exception:
+                logger.exception(
+                    "Error checking block '%s' starting at line %d",
+                    getattr(block, "name", "<unknown>"),
+                    getattr(block, "start_line", -1),
+                )
 
         return diagnostics
 

--- a/src/nwchem_lsp/features/hover.py
+++ b/src/nwchem_lsp/features/hover.py
@@ -5,6 +5,7 @@ This module provides hover documentation for NWChem keywords.
 
 from __future__ import annotations
 
+import logging
 from typing import Any, Optional
 
 from lsprotocol.types import Hover, HoverParams, MarkupContent, MarkupKind, Position
@@ -24,6 +25,8 @@ from ..data.keywords import (
 )
 from ..exceptions import ParseError
 from ..parser.nwchem_parser import NwchemParser
+
+logger = logging.getLogger(__name__)
 
 
 class NwchemHoverProvider:
@@ -55,8 +58,11 @@ class NwchemHoverProvider:
         try:
             parser = NwchemParser(source)
             context = parser.get_context(line_number, column)
-        except (ParseError, Exception):
-            # Return None on parse errors to prevent server crashes
+        except ParseError as exc:
+            logger.warning("Parse error in hover provider: %s", exc)
+            return None
+        except Exception:
+            logger.exception("Unexpected error in hover provider")
             return None
 
         word = context.word_at_cursor

--- a/src/nwchem_lsp/parser/nwchem_parser.py
+++ b/src/nwchem_lsp/parser/nwchem_parser.py
@@ -158,9 +158,11 @@ class NwchemParser:
 
     def get_section_at_line(self, line_number: int) -> Optional[str]:
         """Get the section name at a specific line number."""
+        if line_number < 0:
+            return None
         for section_name, sections in self.sections.items():
             for section in sections:
-                end_line = section.end_line if section.end_line is not None else line_number
+                end_line = section.end_line if section.end_line is not None else float("inf")
                 if section.start_line <= line_number <= end_line:
                     return section_name
         return None

--- a/src/nwchem_lsp/server.py
+++ b/src/nwchem_lsp/server.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from lsprotocol.types import (
@@ -59,6 +60,8 @@ from .features.semantic_tokens import SemanticTokensProvider, get_semantic_token
 from .features.symbols import NwchemSymbolProvider
 from .features.workspace_symbols import WorkspaceSymbolProvider, get_workspace_symbol_provider
 
+logger = logging.getLogger(__name__)
+
 
 class NWChemLanguageServer(LanguageServer):
     """NWChem Language Server Protocol implementation."""
@@ -97,47 +100,71 @@ class NWChemLanguageServer(LanguageServer):
             """Handle completion request."""
             uri = params.text_document.uri
             if uri not in self.documents:
+                logger.warning("Completion requested for unknown document: %s", uri)
                 return []
 
-            text = self.documents[uri]
-            return self.completion_provider.get_completions(text, params.position)
+            try:
+                text = self.documents[uri]
+                return self.completion_provider.get_completions(text, params.position)
+            except Exception:
+                logger.exception("Error processing completion for %s", uri)
+                return []
 
         @self.feature(TEXT_DOCUMENT_HOVER)
         def hover(params: HoverParams) -> Any:
             """Handle hover request."""
             uri = params.text_document.uri
             if uri not in self.documents:
+                logger.warning("Hover requested for unknown document: %s", uri)
                 return None
 
-            text = self.documents[uri]
-            return self.hover_provider.get_hover(text, params.position)
+            try:
+                text = self.documents[uri]
+                return self.hover_provider.get_hover(text, params.position)
+            except Exception:
+                logger.exception("Error processing hover for %s", uri)
+                return None
 
         @self.feature(TEXT_DOCUMENT_DOCUMENT_SYMBOL)
         def document_symbol(params: DocumentSymbolParams) -> list[Any]:
             """Handle document symbol request."""
             uri = params.text_document.uri
             if uri not in self.documents:
+                logger.warning("Document symbol requested for unknown document: %s", uri)
                 return []
 
-            text = self.documents[uri]
-            return self.symbol_provider.get_document_symbols(text)
+            try:
+                text = self.documents[uri]
+                return self.symbol_provider.get_document_symbols(text)
+            except Exception:
+                logger.exception("Error processing document symbols for %s", uri)
+                return []
 
         @self.feature(WORKSPACE_SYMBOL)
         def workspace_symbol(params: WorkspaceSymbolParams) -> list[Any]:
             """Handle workspace symbol request."""
-            return self.workspace_symbol_provider.get_workspace_symbols(
-                params.query, self.documents
-            )
+            try:
+                return self.workspace_symbol_provider.get_workspace_symbols(
+                    params.query, self.documents
+                )
+            except Exception:
+                logger.exception("Error processing workspace symbols")
+                return []
 
         @self.feature(TEXT_DOCUMENT_FORMATTING)
         def formatting(params: DocumentFormattingParams) -> list[Any]:
             """Handle formatting request."""
             uri = params.text_document.uri
             if uri not in self.documents:
+                logger.warning("Formatting requested for unknown document: %s", uri)
                 return []
 
-            text = self.documents[uri]
-            return self.formatting_provider.format_document(text, params)
+            try:
+                text = self.documents[uri]
+                return self.formatting_provider.format_document(text, params)
+            except Exception:
+                logger.exception("Error processing formatting for %s", uri)
+                return []
 
         @self.feature(TEXT_DOCUMENT_DID_OPEN)
         def did_open(params: DidOpenTextDocumentParams) -> None:
@@ -146,9 +173,12 @@ class NWChemLanguageServer(LanguageServer):
             text = params.text_document.text
             self.documents[uri] = text
 
-            # Publish diagnostics
-            diagnostics = self.diagnostic_provider.get_diagnostics(text)
-            self.publish_diagnostics(uri, diagnostics)
+            try:
+                # Publish diagnostics
+                diagnostics = self.diagnostic_provider.get_diagnostics(text)
+                self.publish_diagnostics(uri, diagnostics)
+            except Exception:
+                logger.exception("Error publishing diagnostics on open for %s", uri)
 
         @self.feature(TEXT_DOCUMENT_DID_CHANGE)
         def did_change(params: DidChangeTextDocumentParams) -> None:
@@ -160,9 +190,12 @@ class NWChemLanguageServer(LanguageServer):
                 text = params.content_changes[-1].text
                 self.documents[uri] = text
 
-                # Publish diagnostics
-                diagnostics = self.diagnostic_provider.get_diagnostics(text)
-                self.publish_diagnostics(uri, diagnostics)
+                try:
+                    # Publish diagnostics
+                    diagnostics = self.diagnostic_provider.get_diagnostics(text)
+                    self.publish_diagnostics(uri, diagnostics)
+                except Exception:
+                    logger.exception("Error publishing diagnostics on change for %s", uri)
 
         @self.feature(TEXT_DOCUMENT_DID_SAVE)
         def did_save(params: DidSaveTextDocumentParams) -> None:
@@ -170,85 +203,123 @@ class NWChemLanguageServer(LanguageServer):
             uri = params.text_document.uri
             if uri in self.documents:
                 text = self.documents[uri]
-                diagnostics = self.diagnostic_provider.get_diagnostics(text)
-                self.publish_diagnostics(uri, diagnostics)
+                try:
+                    diagnostics = self.diagnostic_provider.get_diagnostics(text)
+                    self.publish_diagnostics(uri, diagnostics)
+                except Exception:
+                    logger.exception("Error publishing diagnostics on save for %s", uri)
 
         @self.feature(TEXT_DOCUMENT_CODE_ACTION)
         def code_action(params: CodeActionParams) -> list:
             """Handle code action request."""
             uri = params.text_document.uri
             if uri not in self.documents:
+                logger.warning("Code action requested for unknown document: %s", uri)
                 return []
 
-            text = self.documents[uri]
-            diagnostics = params.context.diagnostics if params.context else []
-            return self.code_actions_provider.get_code_actions(text, diagnostics)
+            try:
+                text = self.documents[uri]
+                diagnostics = params.context.diagnostics if params.context else []
+                return self.code_actions_provider.get_code_actions(text, diagnostics)
+            except Exception:
+                logger.exception("Error processing code actions for %s", uri)
+                return []
 
         @self.feature(TEXT_DOCUMENT_DEFINITION)
         def definition(params: DefinitionParams) -> Any:
             """Handle definition request."""
             uri = params.text_document.uri
             if uri not in self.documents:
+                logger.warning("Definition requested for unknown document: %s", uri)
                 return None
 
-            text = self.documents[uri]
-            return self.definition_provider.get_definition(text, params.position)
+            try:
+                text = self.documents[uri]
+                return self.definition_provider.get_definition(text, params.position)
+            except Exception:
+                logger.exception("Error processing definition for %s", uri)
+                return None
 
         @self.feature(TEXT_DOCUMENT_SEMANTIC_TOKENS_FULL)
         def semantic_tokens_full(params: SemanticTokensParams) -> Any:
             """Handle semantic tokens request."""
             uri = params.text_document.uri
             if uri not in self.documents:
+                logger.warning("Semantic tokens requested for unknown document: %s", uri)
                 return None
 
-            text = self.documents[uri]
-            return self.semantic_tokens_provider.get_semantic_tokens(text)
+            try:
+                text = self.documents[uri]
+                return self.semantic_tokens_provider.get_semantic_tokens(text)
+            except Exception:
+                logger.exception("Error processing semantic tokens for %s", uri)
+                return None
 
         @self.feature(TEXT_DOCUMENT_FOLDING_RANGE)
         def folding_range(params: FoldingRangeParams) -> list[Any]:
             """Handle folding range request."""
             uri = params.text_document.uri
             if uri not in self.documents:
+                logger.warning("Folding range requested for unknown document: %s", uri)
                 return []
 
-            text = self.documents[uri]
-            return self.folding_range_provider.get_folding_ranges(text)
+            try:
+                text = self.documents[uri]
+                return self.folding_range_provider.get_folding_ranges(text)
+            except Exception:
+                logger.exception("Error processing folding range for %s", uri)
+                return []
 
         @self.feature(TEXT_DOCUMENT_REFERENCES)
         def references(params: ReferenceParams) -> list[Any]:
             """Handle references request."""
             uri = params.text_document.uri
             if uri not in self.documents:
+                logger.warning("References requested for unknown document: %s", uri)
                 return []
 
-            text = self.documents[uri]
-            return self.references_provider.get_references(
-                text, uri, params.position, params.context.include_declaration
-            )
+            try:
+                text = self.documents[uri]
+                return self.references_provider.get_references(
+                    text, uri, params.position, params.context.include_declaration
+                )
+            except Exception:
+                logger.exception("Error processing references for %s", uri)
+                return []
 
         @self.feature(TEXT_DOCUMENT_RENAME)
         def rename(params: RenameParams) -> Any:
             """Handle rename request."""
             uri = params.text_document.uri
             if uri not in self.documents:
+                logger.warning("Rename requested for unknown document: %s", uri)
                 return None
 
-            text = self.documents[uri]
-            return self.rename_provider.get_rename_edits(
-                text, uri, params.position, params.new_name
-            )
+            try:
+                text = self.documents[uri]
+                return self.rename_provider.get_rename_edits(
+                    text, uri, params.position, params.new_name
+                )
+            except Exception:
+                logger.exception("Error processing rename for %s", uri)
+                return None
 
         @self.feature(TEXT_DOCUMENT_INLAY_HINT)
         def inlay_hint(params: InlayHintParams) -> list[Any]:
             """Handle inlay hints request."""
             uri = params.text_document.uri
             if uri not in self.documents:
+                logger.warning("Inlay hints requested for unknown document: %s", uri)
                 return []
 
-            text = self.documents[uri]
-            start_line = params.range.start.line
-            end_line = params.range.end.line
-            return self.inlay_hints_provider.get_inlay_hints(text, start_line, end_line)
+            try:
+                text = self.documents[uri]
+                start_line = params.range.start.line
+                end_line = params.range.end.line
+                return self.inlay_hints_provider.get_inlay_hints(text, start_line, end_line)
+            except Exception:
+                logger.exception("Error processing inlay hints for %s", uri)
+                return []
 
         @self.feature(INITIALIZED)
         def initialized(_: Any) -> None:


### PR DESCRIPTION
Closes #23

## Changes

### Custom exception classes (`exceptions.py`)
- Added `column` parameter to `ParseError` for precise error location tracking

### Server handlers (`server.py`)
- Added `import logging` and module-level logger
- Wrapped all LSP handler functions (completion, hover, document_symbol, workspace_symbol, formatting, did_open, did_change, did_save, code_action, definition, semantic_tokens, folding_range, references, rename, inlay_hint) in try-except blocks
- Log warnings for missing documents instead of silent returns
- Return safe defaults (empty lists or None) on exception

### Parser boundary fixes (`nwchem_parser.py`)
- `get_section_at_line()`: Added `if line_number < 0: return None` guard
- Changed `end_line` fallback from `line_number` to `float('inf')` for unclosed sections

### Diagnostic provider (`diagnostic.py`)
- Added logging module and logger
- Added logging to existing exception handlers (parse/validation errors and unexpected errors)
- Wrapped per-block checking in try-except with logging to prevent one bad block from crashing diagnostics

### Hover provider (`hover.py`)
- Added logging module and logger
- Replaced bare `except (ParseError, Exception)` with separate handlers: `ParseError` logs a warning, generic `Exception` logs full traceback

### Completion provider (`completion.py`)
- Added logging module and logger
- Wrapped parser construction in try-except, returning empty list on failure
- Logs exceptions instead of silently crashing

All 183 existing tests continue to pass.