### PR TITLE
feat: Add parser parity tests and documentation

### DIFF
--- a/PARITY.md
+++ b/PARITY.md
@@ -1,0 +1,95 @@
+# Parser Parity
+
+## Parser Status
+
+| Parser | Location | Status |
+|--------|----------|--------|
+| **Python** (authoritative) | `src/nwchem_lsp/parser/nwchem_parser.py` | Active, tested, distributed |
+| **TypeScript** (orphaned) | `src/parsers/nw.ts` | Deprecated, reference only |
+
+The Python parser is the sole authoritative implementation used by the LSP
+server. The TypeScript parser was an early prototype and is no longer built,
+tested, or included in any distribution pipeline.
+
+## Feature Coverage Matrix
+
+| Feature | Python | TypeScript | Notes |
+|---------|--------|------------|-------|
+| Section keyword set | Yes | Yes | Identical sets |
+| Top-level keyword set | Yes | Yes | Identical sets |
+| Section parsing (`_parse_sections`) | Yes | Yes | Same algorithm |
+| `get_section_at_line` | Yes | Yes | Same logic |
+| `get_context` | Yes | Yes | Same return shape |
+| `get_completion_context` | Yes | Yes | Same completion types |
+| `is_valid_syntax` | Yes | Yes | Same error messages |
+| `get_all_sections` | Yes | Yes | |
+| `get_section_content` | Yes | Yes | Case-sensitive lookup in Python |
+| `parse()` (blocks) | Yes | No | Python-only: returns section + task blocks |
+| `validate()` (dict output) | Yes | No | Python-only: dict-formatted errors |
+| `parse_task_directives` | Yes | Yes | Both return structured data with default `'energy'` operation |
+| `parse_geometry_block` | Yes | Yes | Both return atoms, units, tags |
+| `parse_basis_blocks` | Yes | Yes | Both return library flag, basis set, elements |
+| `parse_scf_block` | Yes | Yes | Both return maxiter, thresh, tol2e, direct, vectors |
+| `get_line_keywords` | Yes | Yes | Standalone utility function |
+| `parse_nwchem_source` | Yes | Yes | Convenience factory function |
+| Word extraction at cursor | Yes | Yes | Minor: TS includes `_` in regex, Python uses `isalnum()` |
+
+## Known Behavioral Differences
+
+### 1. Word extraction character set
+
+- **TypeScript**: Uses `/[a-zA-Z0-9_]/` regex, which includes underscores.
+- **Python**: Uses `str.isalnum()`, which does not include underscores.
+
+This is unlikely to matter in practice since NWChem identifiers rarely contain
+underscores, but it is a known minor difference.
+
+### 2. Section content lookup case sensitivity
+
+- **TypeScript**: `getSectionContent` lowercases the lookup: `section.name.toLowerCase()`.
+- **Python**: `get_section_content` uses the section name as-is from the `sections` dict.
+
+Since all section names are stored in lowercase internally by both parsers, this
+difference is not observable in practice.
+
+### 3. TypeScript-specific data structures
+
+The TypeScript parser defines explicit interfaces (`GeometryBlock`, `BasisBlock`,
+`SCFBlock`, `TaskDirective`, `AtomCoordinate`). The Python parser now has matching
+dataclasses (`GeometryBlock`, `BasisBlock`, `SCFBlock`, `TaskDirective`,
+`AtomCoordinate`) for full parity.
+
+### 4. `parse_basis_blocks` vs `parseBasisBlock`
+
+- **TypeScript**: `parseBasisBlock()` returns an array of all basis blocks.
+- **Python**: `parse_basis_blocks()` (note plural) returns the same, matching the
+  TypeScript behavior. Named differently to avoid confusion with the singular
+  `parse_geometry_block`/`parse_scf_block` which return the first block only.
+
+## Test Coverage
+
+Parity tests live in `tests/test_parser_parity.py` and mirror the TypeScript test
+suite in `tests/parsers/nw.test.ts`. Each test class corresponds to a `describe`
+block in the TypeScript tests:
+
+| Test Class | TS `describe` Block | Tests |
+|------------|---------------------|-------|
+| `TestTaskDirectiveParsing` | Task Directive Parsing | 5 |
+| `TestStructuredTaskDirectives` | Task Directive Parsing (structured) | 5 |
+| `TestSectionParsing` | Section Management | 7 |
+| `TestGeometryBlockParsing` | Geometry Block Parsing | 4 |
+| `TestBasisBlockParsing` | Basis Block Parsing | 3 |
+| `TestSCFBlockParsing` | SCF Block Parsing | 7 |
+| `TestSyntaxValidation` | Syntax Validation | 3 |
+| `TestContextParsing` | Context Parsing | 3 |
+| `TestEdgeCases` | Basic Parsing + Full Integration | 4 |
+
+Total parity tests: 41
+
+## Maintenance Notes
+
+- The TypeScript parser is **deprecated** and should not receive new features.
+- When adding features to the Python parser, update `tests/test_parser_parity.py`
+  to maintain coverage alignment.
+- The parity tests validate that the Python parser handles at least everything
+  the TypeScript parser handles, not the other way around.

--- a/src/nwchem_lsp/parser/nwchem_parser.py
+++ b/src/nwchem_lsp/parser/nwchem_parser.py
@@ -12,7 +12,7 @@ and not maintained. See the README "Parser Status" section for details.
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Tuple
 
 
@@ -39,6 +39,53 @@ class NWchemSection:
     keywords: List[str]
     content: List[str]
     line_start: int = 0  # Compatibility alias for start_line, set dynamically
+
+
+@dataclass
+class AtomCoordinate:
+    """A single atom coordinate in a geometry block."""
+
+    element: str
+    x: float
+    y: float
+    z: float
+    tag: Optional[str] = None
+
+
+@dataclass
+class GeometryBlock:
+    """Parsed geometry block with units and atom coordinates."""
+
+    units: str = "angstroms"
+    coordinates: List[AtomCoordinate] = field(default_factory=list)
+
+
+@dataclass
+class BasisBlock:
+    """Parsed basis block with library info and elements."""
+
+    basis_set: str = ""
+    library: bool = False
+    elements: List[str] = field(default_factory=list)
+
+
+@dataclass
+class SCFBlock:
+    """Parsed SCF block with calculation parameters."""
+
+    maxiter: Optional[int] = None
+    thresh: Optional[float] = None
+    tol2e: Optional[float] = None
+    direct: Optional[bool] = None
+    vectors: Optional[str] = None
+
+
+@dataclass
+class TaskDirective:
+    """A parsed task directive with theory and operation."""
+
+    theory: str
+    operation: str = "energy"
 
 
 class NwchemParser:
@@ -309,6 +356,168 @@ class NwchemParser:
         for line, message in errors:
             result.append({"line": line, "column": 0, "message": message})
         return result
+
+    # --- Structured block parsers (parity with TypeScript nw.ts) ---
+
+    def parse_task_directives(self) -> List[TaskDirective]:
+        """Parse all task directives from the source.
+
+        Returns a list of TaskDirective objects. When the operation is
+        omitted, it defaults to 'energy', matching NWChem behaviour.
+        """
+        tasks: List[TaskDirective] = []
+        for line in self.lines:
+            stripped = line.strip().lower()
+            if not stripped or stripped.startswith("#"):
+                continue
+            if stripped.startswith("task"):
+                parts = stripped.split()
+                if len(parts) >= 2:
+                    tasks.append(
+                        TaskDirective(
+                            theory=parts[1],
+                            operation=parts[2] if len(parts) >= 3 else "energy",
+                        )
+                    )
+        return tasks
+
+    def parse_geometry_block(self) -> Optional[GeometryBlock]:
+        """Parse the first geometry block into a structured GeometryBlock.
+
+        Returns None when no geometry section is present.
+        """
+        sections = self.sections.get("geometry")
+        if not sections:
+            return None
+
+        section = sections[0]
+        atoms: List[AtomCoordinate] = []
+        units = "angstroms"
+
+        for line in section.content:
+            trimmed = line.strip()
+            if not trimmed or trimmed.startswith("#"):
+                continue
+
+            lower_line = trimmed.lower()
+
+            # Units specification
+            if "units" in lower_line:
+                match = re.search(r"units\s+(\w+)", lower_line)
+                if match:
+                    units = match.group(1)
+                continue
+
+            # Skip end keyword and section header
+            if lower_line == "end" or lower_line.startswith("end "):
+                continue
+            if lower_line == "geometry":
+                continue
+
+            # Parse atom coordinates: "C 0.0 0.0 0.0" or "C 0.0 0.0 0.0 tag"
+            parts = trimmed.split()
+            if len(parts) >= 4:
+                element = parts[0]
+                try:
+                    x = float(parts[1])
+                    y = float(parts[2])
+                    z = float(parts[3])
+                    atoms.append(
+                        AtomCoordinate(
+                            element=element,
+                            x=x,
+                            y=y,
+                            z=z,
+                            tag=parts[4] if len(parts) > 4 else None,
+                        )
+                    )
+                except ValueError:
+                    continue
+
+        return GeometryBlock(units=units, coordinates=atoms)
+
+    def parse_basis_blocks(self) -> List[BasisBlock]:
+        """Parse all basis blocks into structured BasisBlock objects.
+
+        Returns an empty list when no basis section is present.
+        """
+        sections = self.sections.get("basis")
+        if not sections:
+            return []
+
+        result: List[BasisBlock] = []
+        for section in sections:
+            elements: List[str] = []
+            basis_set = ""
+            library = False
+
+            for line in section.content:
+                trimmed = line.strip()
+                if not trimmed or trimmed.startswith("#"):
+                    continue
+
+                lower_line = trimmed.lower()
+                if lower_line == "end" or lower_line.startswith("end "):
+                    continue
+
+                # Check for library keyword
+                if "library" in lower_line:
+                    library = True
+                    match = re.search(r"library\s+(\S+)", lower_line)
+                    if match:
+                        basis_set = match.group(1)
+
+                # Parse element specifications (1-2 letter element symbols)
+                parts = trimmed.split()
+                if parts and re.match(r"^[A-Za-z]{1,2}$", parts[0]):
+                    elements.append(parts[0])
+
+            result.append(
+                BasisBlock(basis_set=basis_set, library=library, elements=elements)
+            )
+        return result
+
+    def parse_scf_block(self) -> Optional[SCFBlock]:
+        """Parse the first SCF block into a structured SCFBlock.
+
+        Returns None when no SCF section is present.
+        """
+        sections = self.sections.get("scf")
+        if not sections:
+            return None
+
+        section = sections[0]
+        scf = SCFBlock()
+
+        for line in section.content:
+            trimmed = line.strip().lower()
+            if not trimmed or trimmed.startswith("#") or trimmed == "end":
+                continue
+
+            if trimmed.startswith("maxiter"):
+                match = re.search(r"maxiter\s+(\d+)", trimmed)
+                if match:
+                    scf.maxiter = int(match.group(1))
+
+            if trimmed.startswith("thresh"):
+                match = re.search(r"thresh\s+([\d.eE+-]+)", trimmed)
+                if match:
+                    scf.thresh = float(match.group(1))
+
+            if trimmed.startswith("tol2e"):
+                match = re.search(r"tol2e\s+([\d.eE+-]+)", trimmed)
+                if match:
+                    scf.tol2e = float(match.group(1))
+
+            if trimmed.startswith("direct"):
+                scf.direct = True
+
+            if trimmed.startswith("vectors"):
+                match = re.search(r"vectors\s+(.+)", trimmed)
+                if match:
+                    scf.vectors = match.group(1).strip()
+
+        return scf
 
 
 def parse_nwchem_source(source: str) -> NwchemParser:

--- a/tests/test_parser_parity.py
+++ b/tests/test_parser_parity.py
@@ -1,0 +1,482 @@
+"""Parser parity tests.
+
+Validates that the Python parser (authoritative) matches the capabilities
+tested in the TypeScript parser test suite (tests/parsers/nw.test.ts).
+These tests ensure behavioral alignment documented in PARITY.md.
+"""
+
+import pytest
+
+from nwchem_lsp.parser.nwchem_parser import (
+    AtomCoordinate,
+    BasisBlock,
+    GeometryBlock,
+    NWchemSection,
+    NwchemParser,
+    SCFBlock,
+    TaskDirective,
+    get_line_keywords,
+    parse_nwchem_source,
+)
+
+
+# ---------------------------------------------------------------------------
+# Task Directive Parsing (mirrors TS: Task Directive Parsing)
+# ---------------------------------------------------------------------------
+
+
+class TestTaskDirectiveParsing:
+    """Parity with TypeScript parseTaskDirectives() tests."""
+
+    def test_single_task_directive(self) -> None:
+        """Python should identify a single task directive."""
+        source = "task scf energy"
+        parser = NwchemParser(source)
+        blocks = parser.parse()
+        task_blocks = [b for b in blocks if b.name == "task"]
+        assert len(task_blocks) == 1
+        assert task_blocks[0].keywords == ["scf", "energy"]
+
+    def test_multiple_task_directives(self) -> None:
+        """Python should identify multiple task directives."""
+        source = "task scf energy\ntask dft optimize\ntask mp2 frequency"
+        parser = NwchemParser(source)
+        blocks = parser.parse()
+        task_blocks = [b for b in blocks if b.name == "task"]
+        assert len(task_blocks) == 3
+        assert task_blocks[0].keywords == ["scf", "energy"]
+        assert task_blocks[1].keywords == ["dft", "optimize"]
+        assert task_blocks[2].keywords == ["mp2", "frequency"]
+
+    def test_task_default_operation(self) -> None:
+        """Python task with no operation should have only theory in keywords."""
+        source = "task scf"
+        parser = NwchemParser(source)
+        blocks = parser.parse()
+        task_blocks = [b for b in blocks if b.name == "task"]
+        assert len(task_blocks) == 1
+        assert task_blocks[0].keywords == ["scf"]
+
+    def test_task_directive_ignores_comments(self) -> None:
+        """Task parsing should skip comment lines."""
+        source = "# Task directive\ntask scf energy"
+        parser = NwchemParser(source)
+        blocks = parser.parse()
+        task_blocks = [b for b in blocks if b.name == "task"]
+        assert len(task_blocks) == 1
+
+    def test_task_inside_section_not_double_counted(self) -> None:
+        """Task directives inside sections should still be found by parse()."""
+        source = "geometry\n  H 0.0 0.0 0.0\nend\ntask scf energy"
+        parser = NwchemParser(source)
+        blocks = parser.parse()
+        task_blocks = [b for b in blocks if b.name == "task"]
+        assert len(task_blocks) == 1
+        assert task_blocks[0].keywords == ["scf", "energy"]
+
+
+# ---------------------------------------------------------------------------
+# Structured TaskDirective parsing (mirrors TS parseTaskDirectives return)
+# ---------------------------------------------------------------------------
+
+
+class TestStructuredTaskDirectives:
+    """Test the parse_task_directives() method returning TaskDirective objects."""
+
+    def test_single_task(self) -> None:
+        """Should return one TaskDirective with theory and operation."""
+        source = "task scf energy"
+        parser = NwchemParser(source)
+        tasks = parser.parse_task_directives()
+        assert len(tasks) == 1
+        assert tasks[0].theory == "scf"
+        assert tasks[0].operation == "energy"
+
+    def test_multiple_tasks(self) -> None:
+        """Should return multiple TaskDirectives."""
+        source = "task scf energy\ntask dft optimize\ntask mp2 frequency"
+        parser = NwchemParser(source)
+        tasks = parser.parse_task_directives()
+        assert len(tasks) == 3
+        assert tasks[0] == TaskDirective(theory="scf", operation="energy")
+        assert tasks[1] == TaskDirective(theory="dft", operation="optimize")
+        assert tasks[2] == TaskDirective(theory="mp2", operation="frequency")
+
+    def test_default_operation_is_energy(self) -> None:
+        """Task with no operation should default to 'energy'."""
+        source = "task scf"
+        parser = NwchemParser(source)
+        tasks = parser.parse_task_directives()
+        assert len(tasks) == 1
+        assert tasks[0].operation == "energy"
+
+    def test_ignores_comments(self) -> None:
+        """Comment lines should not produce task directives."""
+        source = "# Task directive\ntask scf energy"
+        parser = NwchemParser(source)
+        tasks = parser.parse_task_directives()
+        assert len(tasks) == 1
+
+    def test_empty_source_no_tasks(self) -> None:
+        """Empty source should produce no task directives."""
+        parser = NwchemParser("")
+        assert parser.parse_task_directives() == []
+
+
+# ---------------------------------------------------------------------------
+# Section Parsing (mirrors TS: Section Management)
+# ---------------------------------------------------------------------------
+
+
+class TestSectionParsing:
+    """Parity with TypeScript section management tests."""
+
+    def test_parse_empty_source(self) -> None:
+        """Empty source should have no sections."""
+        parser = NwchemParser("")
+        assert parser.get_all_sections() == []
+
+    def test_parse_source_with_only_comments(self) -> None:
+        """Comment-only source should have no sections."""
+        source = "# This is a comment\n# Another comment"
+        parser = NwchemParser(source)
+        assert parser.get_all_sections() == []
+
+    def test_get_all_sections(self) -> None:
+        """Should list all section names."""
+        source = "geometry\nend\nbasis\nend\nscf\nend"
+        parser = NwchemParser(source)
+        sections = parser.get_all_sections()
+        assert "geometry" in sections
+        assert "basis" in sections
+        assert "scf" in sections
+
+    def test_get_section_content(self) -> None:
+        """Should return section content instances."""
+        source = "geometry\n  C 0.0 0.0 0.0\nend"
+        parser = NwchemParser(source)
+        sections = parser.get_section_content("geometry")
+        assert len(sections) == 1
+        assert sections[0].name == "geometry"
+
+    def test_get_section_at_line(self) -> None:
+        """Should identify section at specific lines."""
+        source = "geometry\n  C 0.0 0.0 0.0\nend"
+        parser = NwchemParser(source)
+        assert parser.get_section_at_line(0) == "geometry"
+        assert parser.get_section_at_line(1) == "geometry"
+        assert parser.get_section_at_line(2) == "geometry"
+        assert parser.get_section_at_line(10) is None
+
+    def test_multiple_sections(self) -> None:
+        """Should parse multiple distinct sections."""
+        source = "geometry\n  H 0.0 0.0 0.0\nend\n\nbasis\n  H library 6-31g\nend"
+        parser = NwchemParser(source)
+        assert "geometry" in parser.sections
+        assert "basis" in parser.sections
+        assert len(parser.sections["geometry"]) == 1
+        assert len(parser.sections["basis"]) == 1
+
+    def test_section_content_contains_lines(self) -> None:
+        """Section content should include inner lines."""
+        source = "geometry\n  C 0.0 0.0 0.0\n  H 1.0 0.0 0.0\nend"
+        parser = NwchemParser(source)
+        section = parser.get_section_content("geometry")[0]
+        assert len(section.content) >= 2
+
+
+# ---------------------------------------------------------------------------
+# Structured GeometryBlock parsing (mirrors TS parseGeometryBlock)
+# ---------------------------------------------------------------------------
+
+
+class TestGeometryBlockParsing:
+    """Parity with TypeScript parseGeometryBlock() tests."""
+
+    def test_geometry_with_atoms(self) -> None:
+        """Should parse atoms into AtomCoordinate objects."""
+        source = "geometry\n  C 0.0 0.0 0.0\n  H 1.0 0.0 0.0\n  H 0.0 1.0 0.0\n  H 0.0 0.0 1.0\nend"
+        parser = NwchemParser(source)
+        geometry = parser.parse_geometry_block()
+        assert geometry is not None
+        assert geometry.units == "angstroms"
+        assert len(geometry.coordinates) == 4
+        assert geometry.coordinates[0].element == "C"
+        assert geometry.coordinates[0].x == 0.0
+        assert geometry.coordinates[0].y == 0.0
+        assert geometry.coordinates[0].z == 0.0
+
+    def test_geometry_with_units_bohr(self) -> None:
+        """Should parse units specification."""
+        source = "geometry\n  units bohr\n  H 0.0 0.0 0.0\nend"
+        parser = NwchemParser(source)
+        geometry = parser.parse_geometry_block()
+        assert geometry is not None
+        assert geometry.units == "bohr"
+        assert len(geometry.coordinates) == 1
+
+    def test_geometry_with_atom_tags(self) -> None:
+        """Should parse atom tags."""
+        source = "geometry\n  C 0.0 0.0 0.0 carbon1\n  O 1.2 0.0 0.0 oxygen1\nend"
+        parser = NwchemParser(source)
+        geometry = parser.parse_geometry_block()
+        assert geometry is not None
+        assert geometry.coordinates[0].tag == "carbon1"
+        assert geometry.coordinates[1].tag == "oxygen1"
+
+    def test_no_geometry_returns_none(self) -> None:
+        """No geometry block should return None."""
+        parser = NwchemParser("start molecule")
+        assert parser.parse_geometry_block() is None
+
+
+# ---------------------------------------------------------------------------
+# Structured BasisBlock parsing (mirrors TS parseBasisBlock)
+# ---------------------------------------------------------------------------
+
+
+class TestBasisBlockParsing:
+    """Parity with TypeScript parseBasisBlock() tests."""
+
+    def test_basis_with_library(self) -> None:
+        """Should parse library basis set."""
+        source = "basis\n  * library 6-31g*\nend"
+        parser = NwchemParser(source)
+        blocks = parser.parse_basis_blocks()
+        assert len(blocks) == 1
+        assert blocks[0].basis_set == "6-31g*"
+        assert blocks[0].library is True
+
+    def test_basis_with_explicit_elements(self) -> None:
+        """Should parse element specifications."""
+        source = "basis\n  C library cc-pvdz\n  H library cc-pvdz\nend"
+        parser = NwchemParser(source)
+        blocks = parser.parse_basis_blocks()
+        assert len(blocks) == 1
+        assert "C" in blocks[0].elements
+        assert "H" in blocks[0].elements
+
+    def test_no_basis_returns_empty(self) -> None:
+        """No basis block should return empty list."""
+        parser = NwchemParser("geometry\nend")
+        assert parser.parse_basis_blocks() == []
+
+
+# ---------------------------------------------------------------------------
+# Structured SCFBlock parsing (mirrors TS parseSCFBlock)
+# ---------------------------------------------------------------------------
+
+
+class TestSCFBlockParsing:
+    """Parity with TypeScript parseSCFBlock() tests."""
+
+    def test_scf_maxiter(self) -> None:
+        """Should parse maxiter."""
+        source = "scf\n  maxiter 50\nend"
+        parser = NwchemParser(source)
+        scf = parser.parse_scf_block()
+        assert scf is not None
+        assert scf.maxiter == 50
+
+    def test_scf_thresh(self) -> None:
+        """Should parse thresh."""
+        source = "scf\n  thresh 1e-6\nend"
+        parser = NwchemParser(source)
+        scf = parser.parse_scf_block()
+        assert scf is not None
+        assert scf.thresh == 1e-6
+
+    def test_scf_tol2e(self) -> None:
+        """Should parse tol2e."""
+        source = "scf\n  tol2e 1e-8\nend"
+        parser = NwchemParser(source)
+        scf = parser.parse_scf_block()
+        assert scf is not None
+        assert scf.tol2e == 1e-8
+
+    def test_scf_direct(self) -> None:
+        """Should parse direct flag."""
+        source = "scf\n  direct\nend"
+        parser = NwchemParser(source)
+        scf = parser.parse_scf_block()
+        assert scf is not None
+        assert scf.direct is True
+
+    def test_scf_vectors(self) -> None:
+        """Should parse vectors."""
+        source = "scf\n  vectors input atomic\nend"
+        parser = NwchemParser(source)
+        scf = parser.parse_scf_block()
+        assert scf is not None
+        assert scf.vectors == "input atomic"
+
+    def test_scf_complete_block(self) -> None:
+        """Should parse all SCF parameters together."""
+        source = "scf\n  maxiter 100\n  thresh 1e-7\n  tol2e 1e-9\n  direct\n  vectors input atomic\nend"
+        parser = NwchemParser(source)
+        scf = parser.parse_scf_block()
+        assert scf is not None
+        assert scf.maxiter == 100
+        assert scf.thresh == 1e-7
+        assert scf.tol2e == 1e-9
+        assert scf.direct is True
+        assert scf.vectors == "input atomic"
+
+    def test_no_scf_returns_none(self) -> None:
+        """No SCF block should return None."""
+        parser = NwchemParser("geometry\nend")
+        assert parser.parse_scf_block() is None
+
+
+# ---------------------------------------------------------------------------
+# Syntax validation (mirrors TS: Syntax Validation)
+# ---------------------------------------------------------------------------
+
+
+class TestSyntaxValidation:
+    """Parity with TypeScript isValidSyntax() tests."""
+
+    def test_valid_syntax(self) -> None:
+        """Correctly closed sections should validate."""
+        source = "geometry\nend"
+        parser = NwchemParser(source)
+        is_valid, errors = parser.is_valid_syntax()
+        assert is_valid is True
+        assert len(errors) == 0
+
+    def test_unclosed_section(self) -> None:
+        """Unclosed sections should be detected."""
+        source = "geometry\n  C 0.0 0.0 0.0"
+        parser = NwchemParser(source)
+        is_valid, errors = parser.is_valid_syntax()
+        assert is_valid is False
+        assert len(errors) == 1
+        assert "Unclosed" in errors[0][1]
+
+    def test_unexpected_end(self) -> None:
+        """Unexpected end keyword should be detected."""
+        source = "end"
+        parser = NwchemParser(source)
+        is_valid, errors = parser.is_valid_syntax()
+        assert is_valid is False
+        assert len(errors) == 1
+        assert "Unexpected" in errors[0][1]
+
+
+# ---------------------------------------------------------------------------
+# Context parsing (mirrors TS: Context Parsing)
+# ---------------------------------------------------------------------------
+
+
+class TestContextParsing:
+    """Parity with TypeScript getContext() and getCompletionContext() tests."""
+
+    def test_context_at_position(self) -> None:
+        """Should return correct context at a given position."""
+        source = "geometry\n  C 0.0 0.0 0.0\nend"
+        parser = NwchemParser(source)
+        context = parser.get_context(1, 5)
+        assert context.current_section == "geometry"
+        assert context.line_content == "  C 0.0 0.0 0.0"
+        assert context.is_in_block is True
+
+    def test_word_at_cursor(self) -> None:
+        """Should extract word at cursor position."""
+        source = "start water"
+        parser = NwchemParser(source)
+        context = parser.get_context(0, 8)
+        assert context.word_at_cursor == "water"
+
+    def test_completion_context_task(self) -> None:
+        """Task line should give task_operation completion type."""
+        source = "task scf"
+        parser = NwchemParser(source)
+        completion = parser.get_completion_context(0, 8)
+        assert completion["type"] == "task_operation"
+        assert completion["section"] is None
+
+
+# ---------------------------------------------------------------------------
+# Edge cases and line keywords
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    """Parity with TypeScript getLineKeywords() and edge cases."""
+
+    def test_get_line_keywords(self) -> None:
+        """Should split line into keywords."""
+        assert get_line_keywords("start molecule") == ["start", "molecule"]
+        assert get_line_keywords("  # comment") == []
+        assert get_line_keywords("") == []
+
+    def test_parse_nwchem_source_convenience(self) -> None:
+        """parse_nwchem_source should return a NwchemParser instance."""
+        parser = parse_nwchem_source("geometry\nend")
+        assert isinstance(parser, NwchemParser)
+
+    def test_validate_method(self) -> None:
+        """validate() should return list of dicts."""
+        source = "geometry\n  C 0.0 0.0 0.0"
+        parser = NwchemParser(source)
+        errors = parser.validate()
+        assert isinstance(errors, list)
+        assert len(errors) == 1
+        assert "line" in errors[0]
+        assert "column" in errors[0]
+        assert "message" in errors[0]
+
+    def test_full_input_file_parsing(self) -> None:
+        """Complete NWChem input file should parse all sections + tasks."""
+        source = """start water
+
+title "Water molecule"
+
+geometry
+  O 0.0 0.0 0.0
+  H 0.757 0.586 0.0
+  H -0.757 0.586 0.0
+end
+
+basis
+  * library 6-31g*
+end
+
+scf
+  maxiter 50
+  thresh 1e-6
+end
+
+task scf energy"""
+        parser = NwchemParser(source)
+
+        # Check sections
+        sections = parser.get_all_sections()
+        assert "geometry" in sections
+        assert "basis" in sections
+        assert "scf" in sections
+
+        # Check structured geometry
+        geometry = parser.parse_geometry_block()
+        assert geometry is not None
+        assert len(geometry.coordinates) == 3
+
+        # Check structured basis
+        basis = parser.parse_basis_blocks()
+        assert len(basis) == 1
+        assert basis[0].library is True
+
+        # Check structured SCF
+        scf = parser.parse_scf_block()
+        assert scf is not None
+        assert scf.maxiter == 50
+
+        # Check task directives
+        tasks = parser.parse_task_directives()
+        assert len(tasks) == 1
+        assert tasks[0].theory == "scf"
+        assert tasks[0].operation == "energy"
+
+        # Check syntax validity
+        is_valid, errors = parser.is_valid_syntax()
+        assert is_valid is True


### PR DESCRIPTION
Closes #25

Adds 41 parity tests mirroring the TypeScript parser test suite, new structured parsing methods (task directives, geometry/basis/SCF blocks), and PARITY.md documentation.

- 224 tests pass (183 existing + 41 new)
- Python parser now matches TypeScript capabilities for task directives and structured block parsing
- Documents known behavioral differences and feature coverage matrix