### PR TITLE
feat(lsp): expose live diagnostics snapshots for agent feedback loops

### DIFF
--- a/src/nwchem_lsp/features/diagnostic.py
+++ b/src/nwchem_lsp/features/diagnostic.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import json
 import logging
+from typing import Any
 
 from lsprotocol.types import (
     Diagnostic,
@@ -18,6 +20,14 @@ from ..parser.nwchem_parser import NwchemParser as NWChemParser
 from ..parser.nwchem_parser import NWchemSection
 
 logger = logging.getLogger(__name__)
+
+# Mapping from DiagnosticSeverity enum to human-readable strings.
+_SEVERITY_NAMES: dict[int, str] = {
+    DiagnosticSeverity.Error: "error",
+    DiagnosticSeverity.Warning: "warning",
+    DiagnosticSeverity.Information: "information",
+    DiagnosticSeverity.Hint: "hint",
+}
 
 
 class NwchemDiagnosticProvider:
@@ -98,6 +108,8 @@ class NwchemDiagnosticProvider:
             server: The language server instance.
         """
         self.server = server
+        # Per-URI cache of the most recent diagnostics, used for snapshots.
+        self._diagnostics_cache: dict[str, list[Diagnostic]] = {}
 
     def get_diagnostics(self, text: str) -> list[Diagnostic]:
         """Get diagnostics for the document.
@@ -157,6 +169,102 @@ class NwchemDiagnosticProvider:
                 )
 
         return diagnostics
+
+    def update_cache(self, uri: str, diagnostics: list[Diagnostic]) -> None:
+        """Store diagnostics in the per-URI cache.
+
+        Called by the server after every publish_diagnostics so snapshots
+        always reflect the latest state.
+
+        Args:
+            uri: Document URI.
+            diagnostics: Diagnostics to cache.
+        """
+        self._diagnostics_cache[uri] = list(diagnostics)
+
+    # ------------------------------------------------------------------
+    # Snapshot API
+    # ------------------------------------------------------------------
+
+    def _diagnostic_to_dict(self, diag: Diagnostic) -> dict[str, Any]:
+        """Convert an LSP Diagnostic to a JSON-serializable dict.
+
+        The output is deterministic: fields are ordered and severity is
+        represented as both a numeric code and a human-readable string.
+
+        Args:
+            diag: LSP Diagnostic object.
+
+        Returns:
+            JSON-serializable dictionary.
+        """
+        severity_value = diag.severity if diag.severity is not None else DiagnosticSeverity.Error
+        return {
+            "range": {
+                "start": {
+                    "line": diag.range.start.line,
+                    "character": diag.range.start.character,
+                },
+                "end": {
+                    "line": diag.range.end.line,
+                    "character": diag.range.end.character,
+                },
+            },
+            "severity": severity_value,
+            "severity_label": _SEVERITY_NAMES.get(severity_value, "unknown"),
+            "source": diag.source or "nwchem-lsp",
+            "code": str(diag.code) if diag.code is not None else None,
+            "message": diag.message,
+        }
+
+    def get_diagnostics_snapshot(self, uri: str) -> list[dict[str, Any]]:
+        """Return a JSON-serializable snapshot of diagnostics for a single URI.
+
+        The snapshot reflects the most recently published diagnostics for the
+        document.  Returns an empty list when the URI has not been seen.
+
+        Args:
+            uri: Document URI.
+
+        Returns:
+            List of diagnostic dicts suitable for JSON serialization.
+        """
+        diagnostics = self._diagnostics_cache.get(uri, [])
+        return [self._diagnostic_to_dict(d) for d in diagnostics]
+
+    def get_all_snapshots(self) -> dict[str, list[dict[str, Any]]]:
+        """Return snapshots for every tracked URI.
+
+        Returns:
+            Mapping of URI to its list of diagnostic dicts.
+        """
+        return {
+            uri: [self._diagnostic_to_dict(d) for d in diags]
+            for uri, diags in self._diagnostics_cache.items()
+        }
+
+    def snapshot_to_json(self, uri: str | None = None) -> str:
+        """Render diagnostics as a JSON string.
+
+        When *uri* is provided, returns a JSON array of diagnostics for that
+        single document.  When *uri* is ``None``, returns a JSON object keyed
+        by URI.
+
+        Args:
+            uri: Optional document URI to scope the snapshot.
+
+        Returns:
+            Deterministic JSON string.
+        """
+        if uri is not None:
+            data: Any = self.get_diagnostics_snapshot(uri)
+        else:
+            data = self.get_all_snapshots()
+        return json.dumps(data, indent=2, sort_keys=True)
+
+    # ------------------------------------------------------------------
+    # Block-level checks
+    # ------------------------------------------------------------------
 
     def _check_required_blocks(
         self,

--- a/src/nwchem_lsp/server.py
+++ b/src/nwchem_lsp/server.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 from typing import Any
 
@@ -92,6 +93,16 @@ class NWChemLanguageServer(LanguageServer):
         # Register handlers
         self._register_handlers()
 
+    def _publish_and_cache(self, uri: str, diagnostics: list) -> None:
+        """Publish diagnostics to the client and update the snapshot cache.
+
+        Args:
+            uri: Document URI.
+            diagnostics: Computed diagnostics.
+        """
+        self.publish_diagnostics(uri, diagnostics)
+        self.diagnostic_provider.update_cache(uri, diagnostics)
+
     def _register_handlers(self) -> None:
         """Register LSP handlers."""
 
@@ -176,7 +187,7 @@ class NWChemLanguageServer(LanguageServer):
             try:
                 # Publish diagnostics
                 diagnostics = self.diagnostic_provider.get_diagnostics(text)
-                self.publish_diagnostics(uri, diagnostics)
+                self._publish_and_cache(uri, diagnostics)
             except Exception:
                 logger.exception("Error publishing diagnostics on open for %s", uri)
 
@@ -193,7 +204,7 @@ class NWChemLanguageServer(LanguageServer):
                 try:
                     # Publish diagnostics
                     diagnostics = self.diagnostic_provider.get_diagnostics(text)
-                    self.publish_diagnostics(uri, diagnostics)
+                    self._publish_and_cache(uri, diagnostics)
                 except Exception:
                     logger.exception("Error publishing diagnostics on change for %s", uri)
 
@@ -205,7 +216,7 @@ class NWChemLanguageServer(LanguageServer):
                 text = self.documents[uri]
                 try:
                     diagnostics = self.diagnostic_provider.get_diagnostics(text)
-                    self.publish_diagnostics(uri, diagnostics)
+                    self._publish_and_cache(uri, diagnostics)
                 except Exception:
                     logger.exception("Error publishing diagnostics on save for %s", uri)
 
@@ -326,6 +337,27 @@ class NWChemLanguageServer(LanguageServer):
             """Handle server initialization completion."""
             # Request configuration from client
             pass
+
+        # ------------------------------------------------------------------
+        # Custom LSP command: diagnostics snapshot
+        # ------------------------------------------------------------------
+
+        @self.command("nwchem.diagnosticsSnapshot")
+        def diagnostics_snapshot(arguments: list[Any]) -> str:
+            """Return a JSON diagnostics snapshot.
+
+            Accepts an optional URI as the first argument.  When provided,
+            returns diagnostics for that single document.  Otherwise returns
+            diagnostics for every tracked URI.
+
+            Args:
+                arguments: Optional list with a single URI string.
+
+            Returns:
+                JSON string of diagnostics.
+            """
+            uri: str | None = arguments[0] if arguments else None
+            return self.diagnostic_provider.snapshot_to_json(uri)
 
 
 def create_server() -> NWChemLanguageServer:

--- a/tests/features/test_diagnostic.py
+++ b/tests/features/test_diagnostic.py
@@ -1,5 +1,7 @@
 """Tests for diagnostic providers."""
 
+import json
+
 import pytest
 
 from nwchem_lsp.features.diagnostic import NwchemDiagnosticProvider
@@ -12,6 +14,11 @@ def diagnostic_provider():
 
     server = LanguageServer("test", "1.0")
     return NwchemDiagnosticProvider(server)
+
+
+# ---------------------------------------------------------------------------
+# Existing tests (unchanged)
+# ---------------------------------------------------------------------------
 
 
 class TestNwchemDiagnosticProvider:
@@ -50,3 +57,207 @@ end"""
         # Should report missing geometry
         messages = [d.message for d in diagnostics]
         assert any("geometry" in m.lower() for m in messages)
+
+
+# ---------------------------------------------------------------------------
+# Snapshot tests
+# ---------------------------------------------------------------------------
+
+VALID_INPUT = """\
+geometry
+  H 0 0 0
+end
+
+basis
+  H library 6-31g
+end
+
+task scf energy
+"""
+
+INPUT_WITH_WARNINGS = """\
+geometry
+  H 0 0 0
+end
+
+basis
+  H library fake-basis
+end
+
+task scf energy
+"""
+
+INPUT_WITH_ERRORS = """\
+geometry
+  H 0 0 0
+end
+
+basis
+  H library 6-31g
+end
+
+task badtheory energy
+"""
+
+
+class TestDiagnosticsSnapshot:
+    """Tests for the diagnostics snapshot feature."""
+
+    # -- get_diagnostics_snapshot (per-URI) --
+
+    def test_snapshot_empty_cache(self, diagnostic_provider):
+        """Snapshot returns [] for a URI that was never cached."""
+        snapshot = diagnostic_provider.get_diagnostics_snapshot("file:///unknown.nw")
+        assert snapshot == []
+
+    def test_snapshot_valid_document(self, diagnostic_provider):
+        """Snapshot for a clean document is empty (no diagnostics)."""
+        uri = "file:///test.nw"
+        diags = diagnostic_provider.get_diagnostics(VALID_INPUT)
+        diagnostic_provider.update_cache(uri, diags)
+
+        snapshot = diagnostic_provider.get_diagnostics_snapshot(uri)
+        assert snapshot == []
+
+    def test_snapshot_document_with_warnings(self, diagnostic_provider):
+        """Snapshot captures warnings with correct severity."""
+        uri = "file:///warn.nw"
+        diags = diagnostic_provider.get_diagnostics(INPUT_WITH_WARNINGS)
+        diagnostic_provider.update_cache(uri, diags)
+
+        snapshot = diagnostic_provider.get_diagnostics_snapshot(uri)
+        assert len(snapshot) == 1
+        entry = snapshot[0]
+        assert entry["severity"] == 2  # DiagnosticSeverity.Warning
+        assert entry["severity_label"] == "warning"
+        assert "fake-basis" in entry["message"]
+        assert entry["source"] == "nwchem-lsp"
+        assert isinstance(entry["range"], dict)
+        assert "start" in entry["range"] and "end" in entry["range"]
+
+    def test_snapshot_document_with_errors(self, diagnostic_provider):
+        """Snapshot captures errors with correct severity."""
+        uri = "file:///err.nw"
+        diags = diagnostic_provider.get_diagnostics(INPUT_WITH_ERRORS)
+        diagnostic_provider.update_cache(uri, diags)
+
+        snapshot = diagnostic_provider.get_diagnostics_snapshot(uri)
+        assert len(snapshot) == 1
+        entry = snapshot[0]
+        assert entry["severity"] == 1  # DiagnosticSeverity.Error
+        assert entry["severity_label"] == "error"
+        assert "badtheory" in entry["message"]
+
+    def test_snapshot_fields_present(self, diagnostic_provider):
+        """Every snapshot entry has all required fields."""
+        uri = "file:///fields.nw"
+        diags = diagnostic_provider.get_diagnostics(INPUT_WITH_ERRORS)
+        diagnostic_provider.update_cache(uri, diags)
+
+        snapshot = diagnostic_provider.get_diagnostics_snapshot(uri)
+        assert len(snapshot) >= 1
+        required_keys = {"range", "severity", "severity_label", "source", "code", "message"}
+        for entry in snapshot:
+            assert required_keys.issubset(entry.keys())
+
+    def test_snapshot_updates_after_change(self, diagnostic_provider):
+        """Snapshot reflects the latest diagnostics after a cache update."""
+        uri = "file:///update.nw"
+
+        # First: valid document => no diagnostics
+        diags = diagnostic_provider.get_diagnostics(VALID_INPUT)
+        diagnostic_provider.update_cache(uri, diags)
+        assert diagnostic_provider.get_diagnostics_snapshot(uri) == []
+
+        # Now: introduce errors
+        diags = diagnostic_provider.get_diagnostics(INPUT_WITH_ERRORS)
+        diagnostic_provider.update_cache(uri, diags)
+        snapshot = diagnostic_provider.get_diagnostics_snapshot(uri)
+        assert len(snapshot) == 1
+        assert snapshot[0]["severity_label"] == "error"
+
+    # -- get_all_snapshots --
+
+    def test_get_all_snapshots_empty(self, diagnostic_provider):
+        """get_all_snapshots returns {} when nothing is cached."""
+        assert diagnostic_provider.get_all_snapshots() == {}
+
+    def test_get_all_snapshots_multiple_uris(self, diagnostic_provider):
+        """get_all_snapshots returns per-URI entries for all cached docs."""
+        uri_a = "file:///a.nw"
+        uri_b = "file:///b.nw"
+
+        diags_a = diagnostic_provider.get_diagnostics(VALID_INPUT)
+        diagnostic_provider.update_cache(uri_a, diags_a)
+
+        diags_b = diagnostic_provider.get_diagnostics(INPUT_WITH_ERRORS)
+        diagnostic_provider.update_cache(uri_b, diags_b)
+
+        all_snapshots = diagnostic_provider.get_all_snapshots()
+        assert set(all_snapshots.keys()) == {uri_a, uri_b}
+        assert all_snapshots[uri_a] == []
+        assert len(all_snapshots[uri_b]) == 1
+
+    # -- snapshot_to_json --
+
+    def test_snapshot_to_json_single_uri(self, diagnostic_provider):
+        """snapshot_to_json with a URI produces valid, deterministic JSON."""
+        uri = "file:///json.nw"
+        diags = diagnostic_provider.get_diagnostics(INPUT_WITH_WARNINGS)
+        diagnostic_provider.update_cache(uri, diags)
+
+        json_str = diagnostic_provider.snapshot_to_json(uri)
+        parsed = json.loads(json_str)
+        assert isinstance(parsed, list)
+        assert len(parsed) == 1
+        assert "fake-basis" in parsed[0]["message"]
+
+    def test_snapshot_to_json_all_uris(self, diagnostic_provider):
+        """snapshot_to_json without a URI produces a JSON object keyed by URI."""
+        uri = "file:///jsonall.nw"
+        diags = diagnostic_provider.get_diagnostics(INPUT_WITH_ERRORS)
+        diagnostic_provider.update_cache(uri, diags)
+
+        json_str = diagnostic_provider.snapshot_to_json()
+        parsed = json.loads(json_str)
+        assert isinstance(parsed, dict)
+        assert uri in parsed
+        assert len(parsed[uri]) == 1
+
+    def test_snapshot_json_deterministic(self, diagnostic_provider):
+        """Calling snapshot_to_json twice yields identical output."""
+        uri = "file:///det.nw"
+        diags = diagnostic_provider.get_diagnostics(INPUT_WITH_WARNINGS)
+        diagnostic_provider.update_cache(uri, diags)
+
+        first = diagnostic_provider.snapshot_to_json(uri)
+        second = diagnostic_provider.snapshot_to_json(uri)
+        assert first == second
+
+    # -- _diagnostic_to_dict edge cases --
+
+    def test_diagnostic_dict_code_none(self, diagnostic_provider):
+        """_diagnostic_to_dict handles None code gracefully."""
+        from lsprotocol.types import Diagnostic, DiagnosticSeverity, Position, Range
+
+        diag = Diagnostic(
+            range=Range(start=Position(line=0, character=0), end=Position(line=0, character=1)),
+            message="test",
+            severity=DiagnosticSeverity.Information,
+            source="nwchem-lsp",
+        )
+        result = diagnostic_provider._diagnostic_to_dict(diag)
+        assert result["code"] is None
+        assert result["severity_label"] == "information"
+
+    def test_diagnostic_dict_severity_none_defaults_to_error(self, diagnostic_provider):
+        """When severity is None, it defaults to Error."""
+        from lsprotocol.types import Diagnostic, Position, Range
+
+        diag = Diagnostic(
+            range=Range(start=Position(line=0, character=0), end=Position(line=0, character=1)),
+            message="no severity",
+        )
+        result = diagnostic_provider._diagnostic_to_dict(diag)
+        assert result["severity"] == 1  # Error
+        assert result["severity_label"] == "error"


### PR DESCRIPTION
Implements #40 -- exposes machine-readable diagnostics snapshots for agent feedback loops.

## Changes
- Add `_diagnostics_cache` to `NwchemDiagnosticProvider` for per-URI state
- Add `get_diagnostics_snapshot(uri)` -- returns JSON-serializable list for one document
- Add `get_all_snapshots()` -- returns snapshots for every tracked URI
- Add `snapshot_to_json(uri=None)` -- renders deterministic JSON (single URI or workspace-wide)
- Add `update_cache()` called by server after every publish_diagnostics
- Wire `_publish_and_cache` helper in server to keep cache in sync
- Register custom LSP command `nwchem.diagnosticsSnapshot` for LSP clients
- Each snapshot entry includes: range, severity, severity_label, source, code, message

## Snapshot format (example)
```json
[
  {
    "code": null,
    "message": "Unknown basis set: 'fake-basis'",
    "range": {
      "end": {"character": 25, "line": 4},
      "start": {"character": 15, "line": 4}
    },
    "severity": 2,
    "severity_label": "warning",
    "source": "nwchem-lsp"
  }
]
```

## Testing
- 13 new tests covering empty cache, valid docs, warnings, errors, field presence,
  update-after-change, multi-URI snapshots, JSON output, determinism, and edge cases
- All 267 tests pass (254 existing + 13 new)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>