### PR TITLE
test: add real-world NWChem parse fixtures

### DIFF
--- a/tests/fixtures/real_world/nwchem-official/3carbo.nw
+++ b/tests/fixtures/real_world/nwchem-official/3carbo.nw
@@ -1,0 +1,55 @@
+# Lower temperature dynamics.  Takes much longer
+# for decomposition to occur.
+
+start decomp
+
+echo
+
+Title "3-Carboxybenzisoxazole Gas-phase Dynamics at 500 K"
+
+charge -1
+
+geometry  units angstrom noautoz
+ C     -1.596699713     -2.216151766     0.000000000
+ H     -2.567055941     -2.642705202     -0.1622613519
+ C     -0.4732750318     -3.049311317     0.000000000
+ H     -0.6103720508     -4.113981764     0.000000000
+ C     0.8088326663     -2.537424491     0.000000000
+ H     1.663334370     -3.168175697     0.1273124963
+ C     0.9299163564     -1.158185171     0.000000000
+ C     -0.1710888827     -0.3279462700     0.000000000
+ C     -1.455031178     -0.8428260880     0.000000000
+ C     0.3730189225     1.015119882     0.000000000
+ N     1.655802221     1.015528543     0.000000000
+ O     2.069206744     -0.4126839935     0.000000000
+ C     -0.6503226887     2.495920941     0.000000000
+ O     -0.07121086121     3.567389965     -0.1914702952
+ O     -1.855523825     2.229636669     0.2013747245
+ H     -2.267902137     -0.1509034045     0.000000000
+end
+
+basis
+  H library 3-21G
+  O library 3-21G
+  N library 3-21G
+  C library 3-21G
+end
+
+scf
+  RHF
+  nopen 0
+  thresh 1e-6
+  print low
+end
+
+md
+  system Bzisox_qmd
+  cutoff 2.8
+  noshake solute
+  equil 5  data 30  step 0.0005 # short time for testing
+  isotherm 500.0 trelax 0.2
+  print step 5  stat 10
+  record scoor 1
+end
+
+task scf dynamics

--- a/tests/fixtures/real_world/nwchem-official/3carbo_dft.nw
+++ b/tests/fixtures/real_world/nwchem-official/3carbo_dft.nw
@@ -1,0 +1,53 @@
+#  For testing Quantum MD with DFT energy
+#  Trajectory file can be viewed with Ecce v2.1
+#
+#  In the output file the temp. should drop when
+#  the CO2 is eliminated.  At least 500 ps are needed
+#  to get the decarboxylation to occur at 800 K.
+
+start decomp
+
+echo
+
+Title "3-Carboxybenzisoxazole Gas-phase Dynamics at 800 K"
+
+charge -1
+
+geometry  units angstrom noautoz
+ C     -1.596699713     -2.216151766     0.000000000
+ H     -2.567055941     -2.642705202     -0.1622613519
+ C     -0.4732750318     -3.049311317     0.000000000
+ H     -0.6103720508     -4.113981764     0.000000000
+ C     0.8088326663     -2.537424491     0.000000000
+ H     1.663334370     -3.168175697     0.1273124963
+ C     0.9299163564     -1.158185171     0.000000000
+ C     -0.1710888827     -0.3279462700     0.000000000
+ C     -1.455031178     -0.8428260880     0.000000000
+ C     0.3730189225     1.015119882     0.000000000
+ N     1.655802221     1.015528543     0.000000000
+ O     2.069206744     -0.4126839935     0.000000000
+ C     -0.6503226887     2.495920941     0.000000000
+ O     -0.07121086121     3.567389965     -0.1914702952
+ O     -1.855523825     2.229636669     0.2013747245
+ H     -2.267902137     -0.1509034045     0.000000000
+end
+
+basis
+  * library 3-21G
+end
+
+dft
+  print low
+end
+
+md
+  system Bzisox_qmd
+  cutoff 2.8
+  noshake solute
+  equil 0  data 100  step 0.001
+  isotherm 800.0 trelax 0.05  # heat quickly
+  print step 5  stat 50
+  record scoor 1 prop 1
+end
+
+task dft dynamics

--- a/tests/fixtures/real_world/nwchem-official/README.md
+++ b/tests/fixtures/real_world/nwchem-official/README.md
@@ -1,0 +1,19 @@
+# Official NWChem Real-World Inputs
+
+These fixtures are downloaded from the public NWChem source repository examples
+tree and are used only for parser smoke coverage. They are not executed with
+NWChem during tests.
+
+Retrieved: 2026-06-09
+
+Source repository: https://github.com/nwchemgit/nwchem
+
+License: NWChem source distribution license, see
+https://raw.githubusercontent.com/nwchemgit/nwchem/master/LICENSE.TXT
+
+Fixtures:
+
+- `3carbo.nw` from `examples/qmd/3carbo.nw`
+- `3carbo_dft.nw` from `examples/qmd/3carbo_dft.nw`
+- `h2o_scf.nw` from `examples/qmd/h2o_scf.nw`
+- `ccsd_polar_small.nw` from `examples/tcepolar/ccsd_polar_small.nw`

--- a/tests/fixtures/real_world/nwchem-official/ccsd_polar_small.nw
+++ b/tests/fixtures/real_world/nwchem-official/ccsd_polar_small.nw
@@ -1,0 +1,88 @@
+echo
+
+start ccsd_polar_small
+
+#
+# R = 2.068 bohr
+#
+geometry units au
+ symmetry d2h
+ N  0  0 -1.034
+ N  0  0  1.034
+end
+
+basis spherical
+ * library aug-cc-pVDZ
+end
+
+scf
+  singlet
+  rhf
+  thresh 1e-8
+end
+
+tce
+  scf
+  ccsd
+  io ga
+  2eorb
+end
+
+#
+# This turns on linear response
+#
+set tce:lineresp T
+#
+# Calculate T(1) w.r.t. X and Z only
+#
+set tce:respaxis T F T
+#
+# Dynamic polarizability frequencies in atomic units
+#
+set tce:afreq 0.00000000 0.08855851 0.104551063 0.12977315 0.15187784 # INF, 514.5, 435.8, 351.1, and 300 nm, respectively
+
+task tce energy
+
+#
+# This is what you should get...
+#
+# CCSD Linear Response polarizability / au
+# Frequency = 0.00000 / au
+#       X              Y              Z
+# -----------------------------------------------
+# X      10.0175657      0.0000000      0.0000000
+# Y       0.0000000      0.0000000      0.0000000
+# Z       0.0000000      0.0000000     14.6605433
+# -----------------------------------------------
+# CCSD Linear Response polarizability / au
+# Frequency = 0.08856 / au
+#       X              Y              Z
+# -----------------------------------------------
+# X      10.1996308      0.0000000      0.0000000
+# Y       0.0000000      0.0000000      0.0000000
+# Z       0.0000000      0.0000000     14.9692630
+# -----------------------------------------------
+# CCSD Linear Response polarizability / au
+# Frequency = 0.10455 / au
+#       X              Y              Z
+# -----------------------------------------------
+# X      10.2739888      0.0000000      0.0000000
+# Y       0.0000000      0.0000000      0.0000000
+# Z       0.0000000      0.0000000     15.0954219
+# -----------------------------------------------
+# CCSD Linear Response polarizability / au
+# Frequency = 0.12977 / au
+#       X              Y              Z
+# -----------------------------------------------
+# X      10.4207672      0.0000000      0.0000000
+# Y       0.0000000      0.0000000      0.0000000
+# Z       0.0000000      0.0000000     15.3445592
+# -----------------------------------------------
+# CCSD Linear Response polarizability / au
+# Frequency = 0.15188 / au
+#       X              Y              Z
+# -----------------------------------------------
+# X      10.5821473      0.0000000      0.0000000
+# Y       0.0000000      0.0000000      0.0000000
+# Z       0.0000000      0.0000000     15.6186212
+# -----------------------------------------------

--- a/tests/fixtures/real_world/nwchem-official/h2o_scf.nw
+++ b/tests/fixtures/real_world/nwchem-official/h2o_scf.nw
@@ -1,0 +1,31 @@
+start h2o_scf
+
+geometry units au
+  O 0.00000000 0.00000000 0.24029800
+  H 0.00000000 1.43256600 -0.96119100
+  H 0.00000000 -1.43256600 -0.96119100
+end
+
+basis noprint
+ H library sto-3g
+ O library sto-3g
+end
+
+scf
+  thresh 1.e-10
+  print none
+end
+
+gradients
+  print none
+end
+
+md
+ system h2o_scf
+ equil 0 data 10 step 0.0005
+ print step 1 stat 10
+ record scoor 1 prop 1
+ test 10
+end
+
+task scf dynamics

--- a/tests/parser/test_real_world_fixtures.py
+++ b/tests/parser/test_real_world_fixtures.py
@@ -1,0 +1,21 @@
+"""Parser smoke tests for downloaded NWChem example inputs."""
+
+from pathlib import Path
+
+import pytest
+
+from nwchem_lsp.parser.nwchem_parser import NwchemParser
+
+FIXTURE_DIR = Path(__file__).parents[1] / "fixtures" / "real_world" / "nwchem-official"
+
+
+@pytest.mark.parametrize("fixture_path", sorted(FIXTURE_DIR.glob("*.nw")), ids=lambda p: p.name)
+def test_official_nwchem_examples_parse(fixture_path: Path) -> None:
+    """Real NWChem examples should load into the parser and expose structure."""
+    parser = NwchemParser(fixture_path.read_text(encoding="utf-8"))
+
+    blocks = parser.parse()
+
+    assert blocks, f"{fixture_path.name} produced no parsed blocks"
+    assert parser.get_all_sections(), f"{fixture_path.name} produced no parsed sections"
+    assert any(block.name == "task" for block in blocks), f"{fixture_path.name} has no task block"


### PR DESCRIPTION
## Summary

- add official NWChem example inputs as real-world parser fixtures
- document upstream source URLs, retrieval date, and NWChem source license reference
- add a parse smoke test that loads each fixture, checks parsed sections, and verifies task blocks are exposed

Refs #65 #66 #67

## Sources

All fixtures were downloaded from the public `nwchemgit/nwchem` examples tree on 2026-06-09:

- `examples/qmd/3carbo.nw`
- `examples/qmd/3carbo_dft.nw`
- `examples/qmd/h2o_scf.nw`
- `examples/tcepolar/ccsd_polar_small.nw`

License reference: https://raw.githubusercontent.com/nwchemgit/nwchem/master/LICENSE.TXT

## Verification

- `PYTHONPATH=src python3 -m pytest tests/parser/test_real_world_fixtures.py tests/parser/test_nwchem_parser.py` -> 14 passed
- `python3 -m black tests/parser/test_real_world_fixtures.py`
- `git diff --cached --check`
