### PR TITLE
feat: add LLM Wiki knowledge base

### DIFF
--- a/docs/LLM-WIKI-PLAN.md
+++ b/docs/LLM-WIKI-PLAN.md
@@ -1,0 +1,201 @@
+# LLM Wiki Structure Plan (LLM Wiki 结构计划)
+
+> 项目：nwchem-lsp
+> 创建日期：2026-06-12
+> Wiki 版本：1.0
+
+## 概述 (Overview)
+
+本 Wiki 采用 Karpathy 风格的 LLM 维护模式，将原始证据材料（raw/）与衍生知识页面（wiki/）分离，确保知识可追溯和可更新。
+
+## 目录结构 (Directory Structure)
+
+```
+nwchem-lsp/
+├── raw/
+│   └── assets/
+│       ├── README.md
+│       ├── PLAN.md
+│       ├── AGENTS.md
+│       ├── CHANGELOG.md
+│       ├── architecture.md
+│       ├── DIAGNOSTIC_ENGINE_V1.md
+│       ├── keywords_data.py
+│       ├── nwchem_parser.py
+│       ├── water_dft.nw
+│       ├── benzene_mp2.nw
+│       ├── methane_ccsd.nw
+│       ├── h2o_scf.nw
+│       ├── 3carbo.nw
+│       └── 3carbo_dft.nw
+├── wiki/
+│   ├── entities/       # NWChem 特定实体
+│   │   ├── NWChem.md
+│   │   ├── Geometry_Section.md
+│   │   ├── Basis_Set.md
+│   │   ├── DFT.md
+│   │   ├── Task_Operation.md
+│   │   ├── SCF.md
+│   │   ├── MP2.md
+│   │   ├── CCSD.md
+│   │   ├── ECP.md
+│   │   ├── Chemical_Elements.md
+│   │   ├── XC_Functional.md
+│   │   ├── LSP_Server.md
+│   │   └── Diagnostic_System.md
+│   ├── concepts/       # 跨领域概念
+│   │   ├── Quantum_Chemistry_Methods.md
+│   │   ├── Basis_Set_Selection.md
+│   │   ├── Geometry_Input_Formats.md
+│   │   ├── Convergence_Control.md
+│   │   └── Spin_and_Multiplicity.md
+│   ├── synthesis/      # API 参考和综合文档
+│   │   ├── NWChem_DSL_Reference.md
+│   │   ├── Diagnostics_Catalog.md
+│   │   ├── Feature_Providers_API.md
+│   │   └── Parser_API.md
+│   ├── index.md        # 导航中心
+│   └── log.md          # 变更日志
+```
+
+## 内容分类 (Content Classification)
+
+### 实体页面 (Entity Pages)
+
+NWChem 特定的概念、组件和数据结构：
+
+| 页面 | 描述 | 关键属性 |
+|------|------|---------|
+| NWChem | 量子化学软件 | 方法、功能、输入格式 |
+| Geometry_Section | 几何结构部分 | 单位、选项、格式 |
+| Basis_Set | 基组规范 | 类型、系列、选择策略 |
+| DFT | 密度泛函理论 | 泛函、网格、收敛 |
+| Task_Operation | 任务操作 | 理论、操作类型 |
+| SCF | 自洽场方法 | 自旋态、收敛选项 |
+| MP2 | 二阶微扰理论 | 冻结轨道、近似 |
+| CCSD | 耦合簇方法 | 激发态、精度 |
+| ECP | 有效核势 | 赝势类型、适用元素 |
+| Chemical_Elements | 化学元素 | 118 种元素列表 |
+| XC_Functional | 交换-相关泛函 | LDA、GGA、杂化 |
+| LSP_Server | 语言服务器 | 特性、提供器 |
+| Diagnostic_System | 诊断系统 | 错误类别、快速修复 |
+
+### 概念页面 (Concept Pages)
+
+跨领域的量子化学概念和方法论：
+
+| 页面 | 描述 | 核心内容 |
+|------|------|---------|
+| Quantum_Chemistry_Methods | 方法层级 | 精度/成本权衡 |
+| Basis_Set_Selection | 基组选择 | 选择策略指南 |
+| Geometry_Input_Formats | 几何格式 | 笛卡尔、Z 矩阵 |
+| Convergence_Control | 收敛控制 | SCF、几何优化 |
+| Spin_and_Multiplicity | 自旋多重度 | 单重、二重、三重态 |
+
+### 综合页面 (Synthesis Pages)
+
+API 参考、目录和规范：
+
+| 页面 | 描述 | 内容类型 |
+|------|------|---------|
+| NWChem_DSL_Reference | DSL 语法参考 | 完整语法、示例 |
+| Diagnostics_Catalog | 诊断目录 | 错误代码、修复 |
+| Feature_Providers_API | 特性提供器 | LSP 功能 API |
+| Parser_API | 解析器 API | 类、方法、数据结构 |
+
+## 维护指南 (Maintenance Guidelines)
+
+### 更新规则
+
+1. **原始材料优先** - raw/ 文件不可变，除非用户明确要求
+2. **源引用** - 所有 Wiki 页面必须引用原始来源
+3. **双向链接** - 使用 `[[Wiki_Link]]` 连接相关页面
+4. **变更记录** - 每次更新记录到 log.md
+
+### 页面模板
+
+**实体页面**:
+```markdown
+# Entity_Name
+
+> 类型：材料 / 方法 / 人物 / 组织 / 框架 / 数据集 / 其他
+> 创建日期：YYYY-MM-DD
+> 来源数：N
+
+## 简介
+## 关键属性
+## 相关来源
+## 相关实体/概念
+## 历史更新
+```
+
+**概念页面**:
+```markdown
+# Concept_Name
+
+> 类型：概念
+> 学科/领域：
+
+## 定义
+## 核心机制
+## 应用场景
+## 相关概念
+## 来源
+```
+
+**综合页面**:
+```markdown
+# Topic
+
+> 创建日期：YYYY-MM-DD
+> 最后更新：YYYY-MM-DD
+> 覆盖来源：N
+
+## 核心论点
+## 证据梳理
+## 操作框架
+## 开放问题
+## 来源列表
+```
+
+### 链接约定
+
+- 实体链接：`[[Entity_Name]]`
+- 概念链接：`[[Concept_Name]]`
+- 原始文件：`raw/assets/filename.ext`
+
+## 扩展指南 (Extension Guidelines)
+
+### 添加新实体
+
+1. 在 `wiki/entities/` 创建新页面
+2. 使用实体页面模板
+3. 添加到 `index.md` 目录
+4. 记录到 `log.md`
+
+### 添加新概念
+
+1. 在 `wiki/concepts/` 创建新页面
+2. 使用概念页面模板
+3. 链接相关实体和概念
+4. 更新导航
+
+### 更新现有页面
+
+1. 保持原始引用
+2. 添加更新日期
+3. 记录变更到 log.md
+4. 更新相关链接
+
+## 质量标准 (Quality Standards)
+
+- 所有主张必须有源引用
+- 不确定的信息标注不确定性
+- 使用双语（中文标题，英文术语）
+- 保持 Obsidian 兼容性
+- 维护双向链接一致性
+
+---
+
+**版本历史**:
+- v1.0 (2026-06-12): 初始 Wiki 结构

--- a/raw/assets/3carbo.nw
+++ b/raw/assets/3carbo.nw
@@ -1,0 +1,55 @@
+# Lower temperature dynamics.  Takes much longer
+# for decomposition to occur.
+
+start decomp
+
+echo
+
+Title "3-Carboxybenzisoxazole Gas-phase Dynamics at 500 K"
+
+charge -1
+
+geometry  units angstrom noautoz
+ C     -1.596699713     -2.216151766     0.000000000
+ H     -2.567055941     -2.642705202     -0.1622613519
+ C     -0.4732750318     -3.049311317     0.000000000
+ H     -0.6103720508     -4.113981764     0.000000000
+ C     0.8088326663     -2.537424491     0.000000000
+ H     1.663334370     -3.168175697     0.1273124963
+ C     0.9299163564     -1.158185171     0.000000000
+ C     -0.1710888827     -0.3279462700     0.000000000
+ C     -1.455031178     -0.8428260880     0.000000000
+ C     0.3730189225     1.015119882     0.000000000
+ N     1.655802221     1.015528543     0.000000000
+ O     2.069206744     -0.4126839935     0.000000000
+ C     -0.6503226887     2.495920941     0.000000000
+ O     -0.07121086121     3.567389965     -0.1914702952
+ O     -1.855523825     2.229636669     0.2013747245
+ H     -2.267902137     -0.1509034045     0.000000000
+end
+
+basis
+  H library 3-21G
+  O library 3-21G
+  N library 3-21G
+  C library 3-21G
+end
+
+scf
+  RHF
+  nopen 0
+  thresh 1e-6
+  print low
+end
+
+md
+  system Bzisox_qmd
+  cutoff 2.8
+  noshake solute
+  equil 5  data 30  step 0.0005 # short time for testing
+  isotherm 500.0 trelax 0.2
+  print step 5  stat 10
+  record scoor 1
+end
+
+task scf dynamics

--- a/raw/assets/3carbo_dft.nw
+++ b/raw/assets/3carbo_dft.nw
@@ -1,0 +1,53 @@
+#  For testing Quantum MD with DFT energy
+#  Trajectory file can be viewed with Ecce v2.1
+#
+#  In the output file the temp. should drop when
+#  the CO2 is eliminated.  At least 500 ps are needed
+#  to get the decarboxylation to occur at 800 K.
+
+start decomp
+
+echo
+
+Title "3-Carboxybenzisoxazole Gas-phase Dynamics at 800 K"
+
+charge -1
+
+geometry  units angstrom noautoz
+ C     -1.596699713     -2.216151766     0.000000000
+ H     -2.567055941     -2.642705202     -0.1622613519
+ C     -0.4732750318     -3.049311317     0.000000000
+ H     -0.6103720508     -4.113981764     0.000000000
+ C     0.8088326663     -2.537424491     0.000000000
+ H     1.663334370     -3.168175697     0.1273124963
+ C     0.9299163564     -1.158185171     0.000000000
+ C     -0.1710888827     -0.3279462700     0.000000000
+ C     -1.455031178     -0.8428260880     0.000000000
+ C     0.3730189225     1.015119882     0.000000000
+ N     1.655802221     1.015528543     0.000000000
+ O     2.069206744     -0.4126839935     0.000000000
+ C     -0.6503226887     2.495920941     0.000000000
+ O     -0.07121086121     3.567389965     -0.1914702952
+ O     -1.855523825     2.229636669     0.2013747245
+ H     -2.267902137     -0.1509034045     0.000000000
+end
+
+basis
+  * library 3-21G
+end
+
+dft
+  print low
+end
+
+md
+  system Bzisox_qmd
+  cutoff 2.8
+  noshake solute
+  equil 0  data 100  step 0.001
+  isotherm 800.0 trelax 0.05  # heat quickly
+  print step 5  stat 50
+  record scoor 1 prop 1
+end
+
+task dft dynamics

--- a/raw/assets/AGENTS.md
+++ b/raw/assets/AGENTS.md
@@ -1,0 +1,40 @@
+# AGENTS.md
+
+<!-- repo-governance-kit:agent-ready-v1 -->
+
+## Mission
+
+Implement one GitHub issue per branch. Do not make unrelated changes.
+
+## Required Workflow
+
+1. Read the linked issue, acceptance criteria, test plan, and out-of-scope notes.
+2. Create or update tests before changing behavior when the issue affects code.
+3. Implement the smallest change that satisfies the issue.
+4. Run the local gate before opening a PR:
+   - `make format`
+   - `make lint`
+   - `make typecheck`
+   - `make test`
+   - `make check`
+5. Open the PR with `Fixes #<issue-number>` in the body.
+6. Do not merge until required checks pass and a human reviewer approves.
+
+## Commands
+
+- Install: `make install`
+- Format: `make format`
+- Lint: `make lint`
+- Typecheck: `make typecheck`
+- Test: `make test`
+- Full local check: `make check`
+- Start issue worktree: `scripts/start_issue_worktree.sh <issue> <slug>`
+- Cleanup merged worktrees: `make cleanup-merged`
+
+## Guardrails
+
+- Do not rewrite unrelated files.
+- Do not weaken tests or lint rules to make checks pass.
+- Do not remove existing behavior unless the issue explicitly asks for it.
+- Do not commit secrets, tokens, generated caches, build outputs, or large binary artifacts.
+- If blocked, comment on the issue or PR with the blocker and a minimal reproduction.

--- a/raw/assets/CHANGELOG.md
+++ b/raw/assets/CHANGELOG.md
@@ -1,0 +1,97 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.5.0] - 2026-03-05
+
+### Added
+- **Folding Ranges**: Code folding support for NWChem sections
+  - Fold/unfold geometry, basis, dft, and other sections
+  - Visual indicators for collapsible regions
+- **Find References**: Navigate to all occurrences of a section
+  - Jump between section start and end keywords
+  - Quick navigation within document
+- **Rename Refactoring**: Rename sections with automatic updates
+  - Safe renaming with validation
+  - Workspace-wide edits
+- 26 new tests for v0.5.0 features (total: 186 tests)
+- 100% test coverage maintained
+
+### Changed
+- Updated version from 0.4.0 to 0.5.0
+- Added new LSP handlers for foldingRange, references, and rename
+
+## [0.4.0] - 2026-03-04
+- **Semantic Highlighting**: Token-based syntax highlighting
+  - Section names (namespace)
+  - Task operations (function)
+  - Keywords (variable)
+  - Basis sets (type)
+  - DFT functionals (property)
+  - Chemical elements (class)
+  - Numeric values (number)
+- **Inlay Hints**: Inline information display
+  - Coordinate unit hints (Å)
+  - Task operation descriptions
+  - Charge state descriptions
+  - Convergence threshold hints
+- 42 new tests for v0.4.0 features
+- Total test count increased to 160 (100% coverage maintained)
+
+### Changed
+- Updated version from 0.3.0 to 0.4.0
+- Enhanced LSP server with new feature providers
+
+## [0.3.0] - 2026-03-04
+
+### Added
+- **Code Actions (Quick Fixes)**: LSP code actions for common errors
+  - Auto-fix unclosed sections by adding 'end' keyword
+  - Remove unexpected 'end' keywords
+  - Correct common typos with fuzzy matching (gemoetry → geometry, etc.)
+  - Add missing 'start' directive
+- **Go to Definition**: LSP definition support for navigating NWChem input files
+  - Jump from 'end' keyword to corresponding section start
+- 36 new tests for code actions and definition features
+- Total test count increased to 118 (100% coverage maintained)
+
+## [0.2.1] - 2026-03-03
+
+### Added
+- Comprehensive parser tests (TestParseContext, TestNWchemSection, TestNwchemParser)
+- Feature module tests for completion, hover, and diagnostic providers
+- Test coverage increased from 50 to 82 tests (100% coverage)
+
+### Changed
+- Reorganized test structure with parser/ and features/ subdirectories
+
+## [0.2.0] - 2026-03-03
+
+### Added
+- Document Symbols support for outline view and navigation
+- Code formatting with configurable indentation
+- Enhanced LSP server with documentSymbol and formatting handlers
+
+### Changed
+- Updated version from 0.1.0 to 0.2.0
+- Improved test coverage from 32 to 50 tests (still 100%)
+
+## [0.1.0] - 2026-03-02
+
+### Added
+- Initial release of NWChem LSP
+- Syntax validation for NWChem input files
+- Auto-completion for top-level keywords, sections, basis sets, and DFT functionals
+- Hover documentation for all keywords
+- Diagnostics for unclosed sections and invalid keywords
+- Comprehensive keyword database (60+ elements, 50+ basis sets, 30+ DFT functionals)
+- Full test coverage (32 tests, 100%)
+
+[0.4.0]: https://github.com/newtontech/nwchem-lsp/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/newtontech/nwchem-lsp/compare/v0.2.1...v0.3.0
+[0.2.1]: https://github.com/newtontech/nwchem-lsp/compare/v0.2.0...v0.2.1
+[0.2.0]: https://github.com/newtontech/nwchem-lsp/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/newtontech/nwchem-lsp/releases/tag/v0.1.0

--- a/raw/assets/DIAGNOSTIC_ENGINE_V1.md
+++ b/raw/assets/DIAGNOSTIC_ENGINE_V1.md
@@ -1,0 +1,68 @@
+# Diagnostic Engine v1
+
+This repository implements the shared newtontech Scientific LSP diagnostics
+contract inspired by python-lsp-server's provider model: the editor-facing LSP
+can keep native providers, while the agent-facing layer exposes deterministic
+JSON for check/repair/recheck loops.
+
+## Severity Policy
+
+- `error`: high-confidence syntax, schema, type/value, or reference issue that
+  should block automated submission because the upstream runtime is likely to
+  reject the input.
+- `warning`: high-risk or suspicious input that may be intentional and should
+  be shown to agents without automatically blocking repair loops.
+- `information` / `hint`: style, documentation, or optional optimization facts.
+
+## Categories
+
+- `syntax`
+- `schema`
+- `type/value`
+- `cross-file reference`
+- `semantic consistency`
+- `preflight/runtime-risk`
+- `style/deprecation`
+
+## Rich Diagnostic Shape
+
+Every agent-facing diagnostic must include:
+
+```json
+{
+  "code": "STABLE_CODE",
+  "severity": "error",
+  "category": "schema",
+  "confidence": 1.0,
+  "source": "nwchem-lsp",
+  "range": {
+    "start": {"line": 0, "character": 0},
+    "end": {"line": 0, "character": 1}
+  },
+  "software": "nwchem",
+  "file_type": "input",
+  "path": "input",
+  "expected": null,
+  "actual": null,
+  "manual_ref": null,
+  "fix_hints": [],
+  "blocking": true
+}
+```
+
+## Agent CLI
+
+Use the shared entry point:
+
+```bash
+nwchem-lsp-tool check path/to/input --format json
+nwchem-lsp-tool context path/to/input --format json
+nwchem-lsp-tool complete path/to/input --format json
+nwchem-lsp-tool hover path/to/input --format json
+nwchem-lsp-tool symbols path/to/input --format json
+nwchem-lsp-tool fix path/to/input --format json
+```
+
+`check` is wired to the existing repository diagnostics. The other operations
+reserve stable JSON shapes so downstream agents can call every LSP family with
+the same command surface while each repo fills in richer providers over time.

--- a/raw/assets/PLAN.md
+++ b/raw/assets/PLAN.md
@@ -1,0 +1,92 @@
+# Development Plan for nwchem-lsp
+
+## Overview
+This is the development plan for nwchem-lsp - a Language Server Protocol implementation for NWChem quantum chemistry software.
+
+## Completed Phases
+
+### Phase 1: Foundation ✅
+- [x] Setup project structure
+- [x] Basic parser implementation
+- [x] Initial test suite
+
+### Phase 2: Core Features ✅
+- [x] LSP server implementation
+- [x] Diagnostics support
+- [x] Completion provider
+
+### Phase 3: Advanced Features ✅
+- [x] Hover documentation
+- [x] Parser validation
+- [x] 100% test coverage
+
+### Phase 4: Enhanced LSP Features ✅ (v0.2.0)
+- [x] Document symbols support
+- [x] Code formatting support
+- [x] Expanded test coverage (82 tests)
+
+### Phase 5: Code Actions & Definition ✅ (v0.3.0)
+- [x] Code Actions (Quick Fixes)
+  - Add missing 'end' keywords for unclosed sections
+  - Remove unexpected 'end' keywords
+  - Correct common typos with fuzzy matching
+  - Add missing 'start' directive
+- [x] Go to definition support
+
+### Phase 6: Advanced LSP Features ✅ (v0.4.0)
+- [x] Workspace symbols support
+- [x] Configuration options (via LSP)
+- [x] Semantic highlighting
+- [x] Inlay hints
+
+## Current Status
+- ****Version**: 0.5.0
+- **Parser**: Fully implemented with section parsing, context extraction, and validation
+- **LSP Server**: Complete with all standard LSP features
+- **Test Coverage**: 100% (186 tests passing)
+
+## Test Structure
+```
+tests/
+├── test_basic.py          # Basic import tests
+├── test_server.py         # LSP server tests
+├── test_keywords.py       # Keyword database tests
+├── test_symbols.py        # Document symbols tests
+├── test_formatting.py     # Code formatting tests
+├── parser/
+│   └── test_nwchem_parser.py  # Parser tests
+└── features/
+    ├── test_completion.py     # Completion provider tests
+    ├── test_hover.py          # Hover provider tests
+    ├── test_diagnostic.py     # Diagnostic provider tests
+    ├── test_code_actions.py   # Code actions tests (v0.3.0)
+    ├── test_definition.py     # Definition provider tests (v0.3.0)
+    ├── test_workspace_symbols.py  # Workspace symbols tests (v0.4.0)
+    ├── test_semantic_tokens.py    # Semantic tokens tests (v0.4.0)
+    ├── test_inlay_hints.py        # Inlay hints tests (v0.4.0)
+    └── test_config.py             # Configuration tests (v0.4.0)
+```
+
+## Future Enhancements
+- [x] Folding ranges support
+- [x] References support
+- [x] Rename support
+- [ ] Call hierarchy
+- [ ] Type hierarchy
+- [ ] Rename support
+- [ ] References support
+- [ ] Call hierarchy
+- [ ] Type hierarchy
+- [ ] Folding ranges
+
+## Testing
+- Run tests: `pytest tests/`
+- Check coverage: `pytest --cov`
+- Linting: `pre-commit run --all-files`
+
+## Maintenance
+- Nightly automated maintenance at random time
+- See .maintenance/last-run.md for last check
+
+## Last Updated
+2026-03-04 18:20 CST

--- a/raw/assets/README.md
+++ b/raw/assets/README.md
@@ -1,0 +1,255 @@
+# nwchem-lsp
+
+[![CI](https://github.com/newtontech/nwchem-lsp/workflows/CI/badge.svg)](https://github.com/newtontech/nwchem-lsp/actions)
+[![Coverage](https://codecov.io/gh/newtontech/nwchem-lsp/branch/main/graph/badge.svg)](https://codecov.io/gh/newtontech/nwchem-lsp)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+Language Server Protocol implementation for NWChem quantum chemistry software.
+
+## Features
+
+### Core LSP Features
+- **Syntax Validation**: Real-time diagnostics for NWChem input files
+- **Auto-completion**: Context-aware keyword completion
+  - Top-level keywords (geometry, basis, scf, dft, etc.)
+  - Section-specific keywords
+  - Basis sets and DFT functionals
+  - Task operations and theories
+- **Hover Documentation**: Inline help for all keywords
+- **Document Symbols**: Outline view and navigation
+- **Code Formatting**: Automatic code formatting
+- **Go to Definition**: Navigate from 'end' to section start
+
+### v0.5.0 Features
+- **Folding Ranges**: Code folding for sections
+- **Find References**: Navigate to section occurrences
+- **Rename Refactoring**: Rename sections safely
+
+### v0.4.0 Features
+- **Workspace Symbols**: Global symbol search across all open documents
+- **Configuration Options**: Customizable LSP settings
+- **Semantic Highlighting**: Token-based syntax coloring
+- **Inlay Hints**: Inline information display (units, charge states, etc.)
+
+### Code Actions (Quick Fixes)
+- Add missing 'end' keywords for unclosed sections
+- Remove unexpected 'end' keywords
+- Correct common typos (gemoetry → geometry, etc.)
+- Add missing 'start' directive
+
+### Error Detection
+- Unclosed section blocks
+- Unknown basis sets and functionals
+- Invalid task operations
+- Missing required blocks
+
+## Installation
+
+```bash
+pip install nwchem-lsp
+```
+
+## Usage
+
+### Command Line
+```bash
+nwchem-lsp
+```
+
+### Editor Configuration
+
+#### VS Code
+Add to your `settings.json`:
+```json
+{
+  "languageserver": {
+    "nwchem": {
+      "command": "nwchem-lsp",
+      "filetypes": ["nw", "nwinp"],
+      "rootPatterns": ["*.nw", "*.nwinp"]
+    }
+  }
+}
+```
+
+#### Neovim (nvim-lspconfig)
+```lua
+local lspconfig = require('lspconfig')
+lspconfig.nwchem.setup {
+  cmd = {"nwchem-lsp"},
+  filetypes = {"nw", "nwinp"},
+}
+```
+
+#### Emacs (lsp-mode)
+```elisp
+(lsp-register-client
+ (make-lsp-client :new-connection (lsp-stdio-connection "nwchem-lsp")
+                  :major-modes '(nwchem-mode)
+                  :server-id 'nwchem-lsp))
+```
+
+## Supported File Extensions
+
+- `.nw` - NWChem input files
+- `.nwinp` - NWChem input files (alternative extension)
+
+## Example NWChem Input
+
+```nwchem
+start water
+
+title "Water molecule DFT optimization"
+
+geometry units angstroms
+  O  0.000  0.000  0.000
+  H  0.000  0.790  0.580
+  H  0.000 -0.790  0.580
+end
+
+basis spherical
+  * library 6-31G*
+end
+
+dft
+  xc b3lyp
+  grid fine
+end
+
+task dft optimize
+```
+
+See the `examples/` directory for more sample input files.
+
+## Changelog
+
+### v0.5.0 (2026-03-05)
+- ✨ Added Folding Ranges support
+- ✨ Added Find References support
+- ✨ Added Rename Refactoring support
+- 🧪 Increased test coverage to 186 tests (100%)
+
+
+### v0.4.0 (2026-03-04)
+- ✨ Added Workspace Symbols support
+- ✨ Added Configuration Options (LSP settings)
+- ✨ Added Semantic Highlighting
+- ✨ Added Inlay Hints
+- 🧪 Increased test coverage to 160 tests (100%)
+
+### v0.3.0 (2026-03-04)
+- ✨ Added Code Actions (Quick Fixes) support
+- ✨ Added Go to Definition support
+- 🧪 Increased test coverage to 118 tests (100%)
+
+### v0.2.0 (2026-03-03)
+- ✨ Added Document Symbols support
+- ✨ Added code formatting
+- 🧪 Increased test coverage to 82 tests (100%)
+
+## Development
+
+### Setup
+```bash
+git clone https://github.com/newtontech/nwchem-lsp.git
+cd nwchem-lsp
+pip install -e ".[dev]"
+```
+
+### Running Tests
+```bash
+# Run all tests
+pytest tests/
+
+# Run with coverage
+pytest --cov=src --cov-report=html
+
+# Run specific test file
+pytest tests/test_keywords.py -v
+```
+
+### Code Quality
+```bash
+# Format code
+black src/ tests/
+
+# Sort imports
+isort src/ tests/
+
+# Type checking
+mypy src/
+
+# Security scan
+bandit -r src/
+```
+
+### Pre-commit Hooks
+```bash
+pre-commit install
+pre-commit run --all-files
+```
+
+## Architecture
+
+```
+src/nwchem_lsp/
+├── __init__.py
+├── server.py           # LSP server implementation
+├── parser/
+│   └── nwchem_parser.py # NWChem input file parser
+├── features/
+│   ├── completion.py   # Auto-completion provider
+│   ├── hover.py        # Hover documentation provider
+│   ├── diagnostic.py   # Diagnostics provider
+│   ├── symbols.py      # Document symbols provider
+│   ├── formatting.py   # Code formatting provider
+│   ├── code_actions.py # Code actions/quick fixes
+│   ├── definition.py   # Go to definition provider
+│   ├── workspace_symbols.py  # Workspace symbols (v0.4.0)
+│   ├── semantic_tokens.py    # Semantic highlighting (v0.4.0)
+│   ├── inlay_hints.py        # Inlay hints (v0.4.0)
+│   └── config.py             # Configuration management (v0.4.0)
+└── data/
+    └── keywords.py     # Keyword database
+```
+
+## Supported Keywords
+
+### Top-Level Sections
+- `geometry` - Molecular geometry definition
+- `basis` - Basis set specification
+- `scf` - Hartree-Fock calculations
+- `dft` - Density functional theory
+- `mp2` - MP2 perturbation theory
+- `ccsd` - Coupled cluster methods
+- `ecp` - Effective core potentials
+
+### Task Operations
+- `energy` - Single point energy
+- `optimize` - Geometry optimization
+- `frequencies` - Vibrational analysis
+- `hessian` - Hessian calculation
+- `dynamics` - Molecular dynamics
+
+### Supported Basis Sets
+STO-3G, 3-21G, 6-31G*, 6-311G**, cc-pVDZ, cc-pVTZ, aug-cc-pVTZ, def2-SVP, def2-TZVP, LANL2DZ, and more.
+
+### Supported DFT Functionals
+B3LYP, PBE, PBE0, M06-2X, wB97X-D, CAM-B3LYP, SCAN, and more.
+
+## Contributing
+
+1. Fork the repository
+2. Create a feature branch (`git checkout -b feature/amazing-feature`)
+3. Commit your changes (`git commit -m 'Add amazing feature'`)
+4. Push to the branch (`git push origin feature/amazing-feature`)
+5. Open a Pull Request
+
+## License
+
+MIT License - see [LICENSE](LICENSE) for details.
+
+## Acknowledgments
+
+- [pygls](https://github.com/openlawlibrary/pygls) - Python LSP framework
+- [NWChem](https://nwchem-sw.github.io/) - NWChem quantum chemistry software

--- a/raw/assets/architecture.md
+++ b/raw/assets/architecture.md
@@ -1,0 +1,48 @@
+# NWChem LSP Architecture
+
+## Overview
+
+NWChem LSP is a Language Server Protocol implementation for NWChem quantum chemistry software input files.
+
+## Module Structure
+
+### Parser Module
+- `NwchemParser`: Main parser class
+- `NWchemSection`: Data class representing a section
+- `ParseContext`: Context information for cursor position
+
+### Features Module
+| Provider | Description |
+|----------|-------------|
+| Completion | Auto-completion for keywords |
+| Hover | Inline documentation |
+| Diagnostic | Syntax/error checking |
+| Symbols | Document outline |
+| Workspace Symbols | Global symbol search |
+| Formatting | Code formatting |
+| Code Actions | Quick fixes |
+| Definition | Go to definition |
+| Semantic Tokens | Syntax highlighting |
+| Inlay Hints | Inline information |
+| Folding Range | Code folding |
+| References | Find references |
+| Rename | Rename refactoring |
+
+### Data Module
+- Chemical elements (1-118)
+- Basis sets
+- DFT functionals
+- Task operations
+- Keywords database
+
+## Testing
+
+- **Total Tests**: 186
+- **Coverage**: 100%
+- **Test Categories**: Unit, Integration, Parser, Feature
+
+## References
+
+- [LSP Specification](https://microsoft.github.io/language-server-protocol/)
+- [pygls](https://pygls.readthedocs.io/)
+- [NWChem](https://nwchemgit.github.io/)

--- a/raw/assets/benzene_mp2.nw
+++ b/raw/assets/benzene_mp2.nw
@@ -1,0 +1,31 @@
+# Benzene molecule - MP2 geometry optimization
+# Example NWChem input file
+
+start benzene
+
+title "Benzene MP2/cc-pVTZ geometry optimization"
+
+geometry units angstroms
+  C    1.398000    0.000000    0.000000
+  C    0.699000    1.212000    0.000000
+  C   -0.699000    1.212000    0.000000
+  C   -1.398000    0.000000    0.000000
+  C   -0.699000   -1.212000    0.000000
+  C    0.699000   -1.212000    0.000000
+  H    2.482000    0.000000    0.000000
+  H    1.241000    2.152000    0.000000
+  H   -1.241000    2.152000    0.000000
+  H   -2.482000    0.000000    0.000000
+  H   -1.241000   -2.152000    0.000000
+  H    1.241000   -2.152000    0.000000
+end
+
+basis spherical
+  * library cc-pVTZ
+end
+
+mp2
+  freeze atomic
+end
+
+task mp2 optimize

--- a/raw/assets/ccsd_polar_small.nw
+++ b/raw/assets/ccsd_polar_small.nw
@@ -1,0 +1,88 @@
+echo
+
+start ccsd_polar_small
+
+#
+# R = 2.068 bohr
+#
+geometry units au
+ symmetry d2h
+ N  0  0 -1.034
+ N  0  0  1.034
+end
+
+basis spherical
+ * library aug-cc-pVDZ
+end
+
+scf
+  singlet
+  rhf
+  thresh 1e-8
+end
+
+tce
+  scf
+  ccsd
+  io ga
+  2eorb
+end
+
+#
+# This turns on linear response
+#
+set tce:lineresp T
+#
+# Calculate T(1) w.r.t. X and Z only
+#
+set tce:respaxis T F T
+#
+# Dynamic polarizability frequencies in atomic units
+#
+set tce:afreq 0.00000000 0.08855851 0.104551063 0.12977315 0.15187784 # INF, 514.5, 435.8, 351.1, and 300 nm, respectively
+
+task tce energy
+
+#
+# This is what you should get...
+#
+# CCSD Linear Response polarizability / au
+# Frequency = 0.00000 / au
+#       X              Y              Z
+# -----------------------------------------------
+# X      10.0175657      0.0000000      0.0000000
+# Y       0.0000000      0.0000000      0.0000000
+# Z       0.0000000      0.0000000     14.6605433
+# -----------------------------------------------
+# CCSD Linear Response polarizability / au
+# Frequency = 0.08856 / au
+#       X              Y              Z
+# -----------------------------------------------
+# X      10.1996308      0.0000000      0.0000000
+# Y       0.0000000      0.0000000      0.0000000
+# Z       0.0000000      0.0000000     14.9692630
+# -----------------------------------------------
+# CCSD Linear Response polarizability / au
+# Frequency = 0.10455 / au
+#       X              Y              Z
+# -----------------------------------------------
+# X      10.2739888      0.0000000      0.0000000
+# Y       0.0000000      0.0000000      0.0000000
+# Z       0.0000000      0.0000000     15.0954219
+# -----------------------------------------------
+# CCSD Linear Response polarizability / au
+# Frequency = 0.12977 / au
+#       X              Y              Z
+# -----------------------------------------------
+# X      10.4207672      0.0000000      0.0000000
+# Y       0.0000000      0.0000000      0.0000000
+# Z       0.0000000      0.0000000     15.3445592
+# -----------------------------------------------
+# CCSD Linear Response polarizability / au
+# Frequency = 0.15188 / au
+#       X              Y              Z
+# -----------------------------------------------
+# X      10.5821473      0.0000000      0.0000000
+# Y       0.0000000      0.0000000      0.0000000
+# Z       0.0000000      0.0000000     15.6186212
+# -----------------------------------------------

--- a/raw/assets/ethanol_scf.nw
+++ b/raw/assets/ethanol_scf.nw
@@ -1,0 +1,31 @@
+# Ethanol molecule - HF single point energy
+# Example NWChem input file
+
+start ethanol
+
+title "Ethanol HF/6-311G** single point energy"
+
+geometry units angstroms
+  C     0.000000    0.000000    0.000000
+  C     1.520000    0.000000    0.000000
+  O     2.072000    1.340000    0.000000
+  H    -0.360000   -0.510000    0.900000
+  H    -0.360000   -0.510000   -0.900000
+  H    -0.360000    1.020000    0.000000
+  H     1.880000   -0.510000    0.900000
+  H     1.880000   -0.510000   -0.900000
+  H     3.032000    1.340000    0.000000
+end
+
+basis
+  * library 6-311G**
+end
+
+scf
+  singlet
+  rhf
+  maxiter 100
+  thresh 1e-8
+end
+
+task scf energy

--- a/raw/assets/fe_scf_ecp.nw
+++ b/raw/assets/fe_scf_ecp.nw
@@ -1,0 +1,29 @@
+# Iron atom - SCF with ECP
+# Example demonstrating ECP usage
+
+start fe_ecp
+
+title "Iron atom SCF with LANL2DZ ECP"
+
+charge 2
+
+geometry units angstroms
+  Fe  0.000000  0.000000  0.000000
+end
+
+basis
+  Fe library LANL2DZ
+end
+
+ecp
+  Fe library LANL2DZ
+end
+
+scf
+  quintet
+  uhf
+  maxiter 200
+  thresh 1e-6
+end
+
+task scf energy

--- a/raw/assets/h2o_freq.nw
+++ b/raw/assets/h2o_freq.nw
@@ -1,0 +1,25 @@
+# Water - DFT frequencies
+# Example demonstrating frequency calculation
+
+start h2o_freq
+
+title "Water DFT/B3LYP/6-31G* frequency calculation"
+
+geometry units angstroms
+  O  0.000000  0.000000  0.000000
+  H  0.000000  0.790000  0.580000
+  H  0.000000 -0.790000  0.580000
+end
+
+basis spherical
+  * library 6-31G*
+end
+
+dft
+  xc b3lyp
+  grid fine
+  convergence energy 1e-8
+end
+
+task dft optimize
+task dft frequencies

--- a/raw/assets/h2o_scf.nw
+++ b/raw/assets/h2o_scf.nw
@@ -1,0 +1,31 @@
+start h2o_scf
+
+geometry units au
+  O 0.00000000 0.00000000 0.24029800
+  H 0.00000000 1.43256600 -0.96119100
+  H 0.00000000 -1.43256600 -0.96119100
+end
+
+basis noprint
+ H library sto-3g
+ O library sto-3g
+end
+
+scf
+  thresh 1.e-10
+  print none
+end
+
+gradients
+  print none
+end
+
+md
+ system h2o_scf
+ equil 0 data 10 step 0.0005
+ print step 1 stat 10
+ record scoor 1 prop 1
+ test 10
+end
+
+task scf dynamics

--- a/raw/assets/keywords_data.py
+++ b/raw/assets/keywords_data.py
@@ -1,0 +1,707 @@
+"""NWChem keywords database module.
+
+This module provides comprehensive data structures and functions for NWChem
+input file keywords, including top-level sections, task operations,
+DFT functionals, basis sets, and chemical elements.
+"""
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Set
+
+
+@dataclass
+class KeywordInfo:
+    """Information about an NWChem keyword."""
+
+    name: str
+    description: str
+    section: str
+    required: bool = False
+    arguments: Optional[List[str]] = None
+    example: Optional[str] = None
+    args: List[str] = field(default_factory=list)
+    optional_args: List[str] = field(default_factory=list)
+    requires_block: bool = False
+    deprecated: bool = False
+    deprecated_replacement: Optional[str] = None
+    allowed_values: Optional[List[str]] = None
+
+
+# Chemical elements
+ELEMENTS: List[str] = [
+    "H",
+    "He",
+    "Li",
+    "Be",
+    "B",
+    "C",
+    "N",
+    "O",
+    "F",
+    "Ne",
+    "Na",
+    "Mg",
+    "Al",
+    "Si",
+    "P",
+    "S",
+    "Cl",
+    "Ar",
+    "K",
+    "Ca",
+    "Sc",
+    "Ti",
+    "V",
+    "Cr",
+    "Mn",
+    "Fe",
+    "Co",
+    "Ni",
+    "Cu",
+    "Zn",
+    "Ga",
+    "Ge",
+    "As",
+    "Se",
+    "Br",
+    "Kr",
+    "Rb",
+    "Sr",
+    "Y",
+    "Zr",
+    "Nb",
+    "Mo",
+    "Tc",
+    "Ru",
+    "Rh",
+    "Pd",
+    "Ag",
+    "Cd",
+    "In",
+    "Sn",
+    "Sb",
+    "Te",
+    "I",
+    "Xe",
+    "Cs",
+    "Ba",
+    "La",
+    "Ce",
+    "Pr",
+    "Nd",
+    "Pm",
+    "Sm",
+    "Eu",
+    "Gd",
+    "Tb",
+    "Dy",
+    "Ho",
+    "Er",
+    "Tm",
+    "Yb",
+    "Lu",
+    "Hf",
+    "Ta",
+    "W",
+    "Re",
+    "Os",
+    "Ir",
+    "Pt",
+    "Au",
+    "Hg",
+    "Tl",
+    "Pb",
+    "Bi",
+    "Po",
+    "At",
+    "Rn",
+    "Fr",
+    "Ra",
+    "Ac",
+    "Th",
+    "Pa",
+    "U",
+    "Np",
+    "Pu",
+    "Am",
+    "Cm",
+    "Bk",
+    "Cf",
+    "Es",
+    "Fm",
+    "Md",
+    "No",
+    "Lr",
+    "Rf",
+    "Db",
+    "Sg",
+    "Bh",
+    "Hs",
+    "Mt",
+    "Ds",
+    "Rg",
+    "Cn",
+    "Nh",
+    "Fl",
+    "Mc",
+    "Lv",
+    "Ts",
+    "Og",
+]
+
+# DFT Exchange-Correlation Functionals
+DFT_FUNCTIONALS: List[str] = [
+    "LDA",
+    "S",
+    "BLYP",
+    "PBE",
+    "BP86",
+    "PW91",
+    "B97-D",
+    "B3LYP",
+    "PBE0",
+    "BHLYP",
+    "B3PW91",
+    "B1LYP",
+    "TPSS",
+    "M06-L",
+    "M06",
+    "M06-2X",
+    "M06-HF",
+    "SCAN",
+    "RSCAN",
+    "R2SCAN",
+    "LC-BLYP",
+    "LC-PBE",
+    "CAM-B3LYP",
+    "wB97",
+    "wB97X",
+    "wB97X-D",
+    "M11",
+    "M11-L",
+    "M08-HX",
+    "M08-SO",
+    "MN12-L",
+    "MN12-SX",
+    "X3LYP",
+    "O3LYP",
+    "B97-1",
+    "B97-2",
+    "B98",
+    "PBEsol",
+]
+
+# Common basis sets
+BASIS_SETS: List[str] = [
+    "STO-3G",
+    "3-21G",
+    "6-31G",
+    "6-311G",
+    "6-31G*",
+    "6-31G(d)",
+    "6-31G**",
+    "6-31G(d,p)",
+    "6-311G*",
+    "6-311G(d)",
+    "6-311G**",
+    "6-311G(d,p)",
+    "6-31+G*",
+    "6-31++G**",
+    "6-311+G*",
+    "6-311++G**",
+    "cc-pVDZ",
+    "cc-pVTZ",
+    "cc-pVQZ",
+    "cc-pV5Z",
+    "cc-pV6Z",
+    "aug-cc-pVDZ",
+    "aug-cc-pVTZ",
+    "aug-cc-pVQZ",
+    "aug-cc-pV5Z",
+    "cc-pCVDZ",
+    "cc-pCVTZ",
+    "cc-pCVQZ",
+    "def2-SVP",
+    "def2-TZVP",
+    "def2-TZVPP",
+    "def2-QZVP",
+    "def2-QZVPP",
+    "LANL2DZ",
+    "LANL2TZ",
+    "SDD",
+    "DGDZVP",
+    "MINI",
+    "MIDI",
+]
+
+# Task operations
+TASK_OPERATIONS: List[str] = [
+    "energy",
+    "gradient",
+    "optimize",
+    "saddle",
+    "hessian",
+    "frequencies",
+    "freq",
+    "vib",
+    "property",
+    "dynamics",
+    "thermodynamics",
+    "tce",
+    "ccsd",
+    "ccsd(t)",
+    "ccsd[t]",
+    "mp2",
+    "mp3",
+    "mp4",
+    "rimp2",
+    "mcscf",
+    "selci",
+    "pspw",
+    "band",
+    "paw",
+    "ofpw",
+]
+
+# Task theories
+TASK_THEORIES: List[str] = ["scf", "dft", "mp2", "ccsd", "ccsd(t)", "mcscf", "semi", "rimp2"]
+
+# Top-level sections that require blocks
+TOP_LEVEL_SECTIONS: List[str] = [
+    "geometry",
+    "basis",
+    "scf",
+    "dft",
+    "mp2",
+    "ccsd",
+    "ccsd(t)",
+    "ecp",
+    "so",
+    "tce",
+    "mcscf",
+    "selci",
+    "hessian",
+    "vib",
+    "property",
+    "rt_tddft",
+    "pspw",
+    "band",
+    "paw",
+    "ofpw",
+    "bq",
+]
+
+# Top-level NWChem keywords
+TOP_LEVEL_KEYWORDS: Dict[str, KeywordInfo] = {
+    "geometry": KeywordInfo(
+        name="geometry",
+        description="Define molecular geometry section",
+        section="top",
+        required=True,
+        requires_block=True,
+        arguments=["units", "angstroms", "bohr", "autosym", "noautoz", "nocenter", "center"],
+        example="geometry units angstroms\n  O  0.0  0.0  0.0\n  H  0.0  0.8  0.6\n  H  0.0 -0.8  0.6\nend",
+        args=["units", "angstroms", "bohr"],
+    ),
+    "basis": KeywordInfo(
+        name="basis",
+        description="Define basis set specification",
+        section="top",
+        required=True,
+        requires_block=True,
+        arguments=["spherical", "cartesian"],
+        example="basis spherical\n  * library 6-31G*\nend",
+    ),
+    "charge": KeywordInfo(
+        name="charge",
+        description="Set total molecular charge",
+        section="top",
+        required=False,
+        arguments=["integer"],
+        example="charge 0",
+    ),
+    "scf": KeywordInfo(
+        name="scf",
+        description="Self-Consistent Field (Hartree-Fock) calculation",
+        section="top",
+        required=False,
+        requires_block=True,
+        arguments=[
+            "singlet",
+            "doublet",
+            "triplet",
+            "quartet",
+            "quintet",
+            "rhf",
+            "uhf",
+            "rohf",
+            "mcscf",
+            "thresh",
+            "maxiter",
+            "direct",
+            "semidirect",
+        ],
+        example="scf\n  singlet\n  rhf\n  maxiter 100\nend",
+    ),
+    "dft": KeywordInfo(
+        name="dft",
+        description="Density Functional Theory calculation",
+        section="top",
+        required=False,
+        requires_block=True,
+        arguments=[
+            "xc",
+            "grid",
+            "tolerances",
+            "convergence",
+            "iterations",
+            "direct",
+            "noio",
+            "odft",
+            "cdft",
+            "mult",
+        ],
+        example="dft\n  xc b3lyp\n  grid fine\n  convergence energy 1e-8\nend",
+    ),
+    "mp2": KeywordInfo(
+        name="mp2",
+        description="Second-order Moller-Plesset perturbation theory",
+        section="top",
+        required=False,
+        requires_block=True,
+        arguments=["tight", "freeze", "scratch disk", "ri", "cd", "thize", "thize_g"],
+        example="mp2\n  freeze atomic\nend",
+    ),
+    "ccsd": KeywordInfo(
+        name="ccsd",
+        description="Coupled Cluster Singles and Doubles",
+        section="top",
+        required=False,
+        requires_block=True,
+        arguments=["tce", "freeze", "thresh", "maxiter", "io", "diis", "nodis", "ccsd(t)"],
+        example="ccsd\n  freeze atomic\n  thresh 1e-6\nend",
+    ),
+    "ecp": KeywordInfo(
+        name="ecp",
+        description="Effective Core Potential specification",
+        section="top",
+        required=False,
+        requires_block=True,
+        arguments=["library"],
+        example="ecp\n  Pt library LANL2DZ\nend",
+    ),
+    "task": KeywordInfo(
+        name="task",
+        description="Execute a computational task",
+        section="top",
+        required=True,
+        requires_block=False,
+        arguments=TASK_OPERATIONS,
+        args=["theory", "operation"],
+        example="task dft optimize",
+    ),
+    "set": KeywordInfo(
+        name="set",
+        description="Set a variable or parameter",
+        section="top",
+        required=False,
+        arguments=["variable_name", "value"],
+        example="set geometry:units bohr",
+    ),
+    "unset": KeywordInfo(
+        name="unset",
+        description="Unset a variable",
+        section="top",
+        required=False,
+        arguments=["variable_name"],
+        example="unset geometry:units",
+    ),
+    "echo": KeywordInfo(
+        name="echo",
+        description="Echo a string to output",
+        section="top",
+        required=False,
+        arguments=["string"],
+        example='echo "Starting calculation"',
+    ),
+    "start": KeywordInfo(
+        name="start",
+        description="Specify restart file name",
+        section="top",
+        required=False,
+        arguments=["filename"],
+        example="start water",
+    ),
+    "restart": KeywordInfo(
+        name="restart",
+        description="Restart from a previous calculation",
+        section="top",
+        required=False,
+        arguments=["filename"],
+        example="restart water",
+    ),
+    "permanent_dir": KeywordInfo(
+        name="permanent_dir",
+        description="Set permanent directory for large files",
+        section="top",
+        required=False,
+        arguments=["path"],
+        example="permanent_dir /tmp/scratch",
+    ),
+    "scratch_dir": KeywordInfo(
+        name="scratch_dir",
+        description="Set scratch directory for temporary files",
+        section="top",
+        required=False,
+        arguments=["path"],
+        example="scratch_dir /tmp/scratch",
+    ),
+    "memory": KeywordInfo(
+        name="memory",
+        description="Set memory limits for calculation",
+        section="top",
+        required=False,
+        arguments=["total", "stack", "heap", "global"],
+        example="memory total 4 gb",
+    ),
+    "title": KeywordInfo(
+        name="title",
+        description="Set a title for the calculation",
+        section="top",
+        required=False,
+        arguments=["string"],
+        example='title "Water molecule optimization"',
+    ),
+    "print": KeywordInfo(
+        name="print",
+        description="Control printing level",
+        section="top",
+        required=False,
+        arguments=["none", "low", "medium", "high", "debug"],
+        example="print high",
+    ),
+}
+
+# DFT-specific keywords
+DFT_KEYWORDS: Dict[str, KeywordInfo] = {
+    "xc": KeywordInfo(
+        name="xc",
+        description="Exchange-correlation functional",
+        section="dft",
+        arguments=DFT_FUNCTIONALS,
+        args=["functional"],
+    ),
+    "grid": KeywordInfo(
+        name="grid",
+        description="Numerical integration grid",
+        section="dft",
+        arguments=["coarse", "medium", "fine", "xfine", "ultrafine"],
+    ),
+    "convergence": KeywordInfo(
+        name="convergence",
+        description="SCF convergence criteria",
+        section="dft",
+        arguments=["energy", "density", "gradient"],
+    ),
+    "iterations": KeywordInfo(
+        name="iterations",
+        description="Maximum number of SCF iterations",
+        section="dft",
+        arguments=["integer"],
+    ),
+    "direct": KeywordInfo(
+        name="direct", description="Force direct SCF (recalculate integrals)", section="dft"
+    ),
+    "noio": KeywordInfo(name="noio", description="Disable disk I/O for integrals", section="dft"),
+    "odft": KeywordInfo(name="odft", description="Open-shell DFT calculation", section="dft"),
+    "mult": KeywordInfo(
+        name="mult", description="Spin multiplicity", section="dft", arguments=["integer"]
+    ),
+}
+
+# SCF-specific keywords
+SCF_KEYWORDS: Dict[str, KeywordInfo] = {
+    "singlet": KeywordInfo(name="singlet", description="Singlet spin state", section="scf"),
+    "doublet": KeywordInfo(name="doublet", description="Doublet spin state", section="scf"),
+    "triplet": KeywordInfo(name="triplet", description="Triplet spin state", section="scf"),
+    "rhf": KeywordInfo(name="rhf", description="Restricted Hartree-Fock", section="scf"),
+    "uhf": KeywordInfo(name="uhf", description="Unrestricted Hartree-Fock", section="scf"),
+    "rohf": KeywordInfo(
+        name="rohf", description="Restricted open-shell Hartree-Fock", section="scf"
+    ),
+    "maxiter": KeywordInfo(
+        name="maxiter",
+        description="Maximum number of SCF iterations",
+        section="scf",
+        arguments=["integer"],
+    ),
+    "thresh": KeywordInfo(
+        name="thresh", description="Convergence threshold", section="scf", arguments=["float"]
+    ),
+}
+
+# Geometry keywords
+GEOMETRY_KEYWORDS: Dict[str, KeywordInfo] = {
+    "units": KeywordInfo(
+        name="units",
+        description="Units for geometry coordinates",
+        section="geometry",
+        arguments=["angstroms", "bohr", "nanometers", "picometers"],
+    ),
+    "autosym": KeywordInfo(
+        name="autosym", description="Automatic symmetry detection", section="geometry"
+    ),
+    "noautoz": KeywordInfo(
+        name="noautoz", description="Disable automatic Z-matrix generation", section="geometry"
+    ),
+    "center": KeywordInfo(
+        name="center", description="Center geometry at origin", section="geometry"
+    ),
+    "nocenter": KeywordInfo(
+        name="nocenter", description="Do not center geometry", section="geometry"
+    ),
+    "system": KeywordInfo(
+        name="system",
+        description="Periodic boundary conditions",
+        section="geometry",
+        arguments=["crystal", "slab", "polymer", "helix"],
+    ),
+    "angstroms": KeywordInfo(
+        name="angstroms", description="Use angstrom units", section="geometry"
+    ),
+    "au": KeywordInfo(name="au", description="Use atomic units (bohr)", section="geometry"),
+    "bohr": KeywordInfo(name="bohr", description="Use bohr units", section="geometry"),
+}
+
+# Basis set keywords
+BASIS_KEYWORDS: Dict[str, KeywordInfo] = {
+    "spherical": KeywordInfo(
+        name="spherical", description="Use spherical harmonic basis functions", section="basis"
+    ),
+    "cartesian": KeywordInfo(
+        name="cartesian", description="Use Cartesian basis functions", section="basis"
+    ),
+    "library": KeywordInfo(
+        name="library",
+        description="Use basis set from library",
+        section="basis",
+        arguments=BASIS_SETS,
+    ),
+    "file": KeywordInfo(
+        name="file", description="Read basis set from file", section="basis", arguments=["filename"]
+    ),
+}
+
+# MP2 keywords
+MP2_KEYWORDS: Dict[str, KeywordInfo] = {
+    "tight": KeywordInfo(name="tight", description="Use tight convergence criteria", section="mp2"),
+    "freeze": KeywordInfo(
+        name="freeze", description="Freeze orbitals", section="mp2", arguments=["atomic", "integer"]
+    ),
+    "ri": KeywordInfo(name="ri", description="Use RI approximation", section="mp2"),
+    "cd": KeywordInfo(name="cd", description="Use Cholesky decomposition", section="mp2"),
+}
+
+# CC keywords
+CC_KEYWORDS: Dict[str, KeywordInfo] = {
+    "tce": KeywordInfo(name="tce", description="Use Tensor Contraction Engine", section="cc"),
+    "freeze": KeywordInfo(
+        name="freeze", description="Freeze orbitals", section="cc", arguments=["atomic", "integer"]
+    ),
+    "thresh": KeywordInfo(name="thresh", description="Convergence threshold", section="cc"),
+    "maxiter": KeywordInfo(name="maxiter", description="Maximum iterations", section="cc"),
+}
+
+# Task keywords
+TASK_KEYWORDS: Dict[str, KeywordInfo] = {
+    "energy": KeywordInfo(
+        name="energy", description="Single point energy calculation", section="task"
+    ),
+    "optimize": KeywordInfo(name="optimize", description="Geometry optimization", section="task"),
+    "frequencies": KeywordInfo(
+        name="frequencies", description="Frequency calculation", section="task"
+    ),
+    "gradient": KeywordInfo(name="gradient", description="Gradient calculation", section="task"),
+    "hessian": KeywordInfo(name="hessian", description="Hessian calculation", section="task"),
+}
+
+# Charge keywords
+CHARGE_KEYWORDS: Dict[str, KeywordInfo] = {
+    "charge": KeywordInfo(name="charge", description="Set molecular charge", section="charge"),
+}
+
+# All keywords by section
+ALL_KEYWORDS: Dict[str, Dict[str, KeywordInfo]] = {
+    "top": TOP_LEVEL_KEYWORDS,
+    "dft": DFT_KEYWORDS,
+    "scf": SCF_KEYWORDS,
+    "geometry": GEOMETRY_KEYWORDS,
+    "basis": BASIS_KEYWORDS,
+    "mp2": MP2_KEYWORDS,
+    "cc": CC_KEYWORDS,
+    "task": TASK_KEYWORDS,
+    "charge": CHARGE_KEYWORDS,
+}
+
+# Flattened KEYWORDS dictionary for compatibility
+KEYWORDS: Dict[str, KeywordInfo] = {}
+for section_dict in ALL_KEYWORDS.values():
+    KEYWORDS.update(section_dict)
+
+
+def get_keyword_info(name: str, section: str = "top") -> Optional[KeywordInfo]:
+    """Get information about a specific keyword."""
+    section_dict = ALL_KEYWORDS.get(section, {})
+    return section_dict.get(name.lower())
+
+
+def get_keyword(name: str) -> Optional[KeywordInfo]:
+    """Get keyword info by name (case-insensitive)."""
+    return KEYWORDS.get(name.lower())
+
+
+def get_all_keywords() -> List[str]:
+    """Get a list of all available keyword names."""
+    keywords: Set[str] = set()
+    for section_dict in ALL_KEYWORDS.values():
+        keywords.update(section_dict.keys())
+    return sorted(list(keywords))
+
+
+def get_all_keyword_names() -> List[str]:
+    """Get all keyword names (alias for get_all_keywords)."""
+    return get_all_keywords()
+
+
+def get_keywords_by_section(section: str) -> List[KeywordInfo]:
+    """Get keywords for a specific section."""
+    section_dict = ALL_KEYWORDS.get(section.lower(), {})
+    return list(section_dict.values())
+
+
+def get_section_keywords(section: str) -> Dict[str, KeywordInfo]:
+    """Get all keyword info objects for a specific section."""
+    return ALL_KEYWORDS.get(section.lower(), {}).copy()
+
+
+def is_valid_keyword(name: str, section: str = "top") -> bool:
+    """Check if a keyword is valid."""
+    return get_keyword_info(name, section) is not None
+
+
+def is_section_block(name: str) -> bool:
+    """Check if a keyword is a section block keyword."""
+    kw = KEYWORDS.get(name.lower())
+    if kw:
+        return kw.requires_block
+    return name.lower() in TOP_LEVEL_SECTIONS
+
+
+def get_keyword_sections() -> List[str]:
+    """Get a list of all available keyword sections."""
+    return sorted(list(ALL_KEYWORDS.keys()))
+
+
+def get_all_sections() -> List[str]:
+    """Get all available sections."""
+    return get_keyword_sections()

--- a/raw/assets/methane_ccsd.nw
+++ b/raw/assets/methane_ccsd.nw
@@ -1,0 +1,27 @@
+# Methane - CCSD(T) single point
+# Example demonstrating coupled cluster calculation
+
+start methane_ccsdt
+
+title "Methane CCSD(T)/cc-pVTZ single point"
+
+memory total 2 gb
+
+geometry units angstroms
+  C   0.000000   0.000000   0.000000
+  H   0.629118   0.629118   0.629118
+  H  -0.629118  -0.629118   0.629118
+  H  -0.629118   0.629118  -0.629118
+  H   0.629118  -0.629118  -0.629118
+end
+
+basis spherical
+  * library cc-pVTZ
+end
+
+ccsd
+  freeze atomic
+  thresh 1e-7
+end
+
+task ccsd(t) energy

--- a/raw/assets/nwchem_parser.py
+++ b/raw/assets/nwchem_parser.py
@@ -1,0 +1,321 @@
+"""NWChem input file parser.
+
+This module provides parsing capabilities for NWChem input files (.nw),
+including section identification, line context extraction, and completion
+context determination.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple
+
+
+@dataclass
+class ParseContext:
+    """Context information for a parsed NWChem file."""
+
+    line_number: int
+    column: int
+    current_section: Optional[str]
+    section_stack: List[str]
+    line_content: str
+    word_at_cursor: str
+    is_in_block: bool
+
+
+@dataclass
+class NWchemSection:
+    """Represents an NWChem input section."""
+
+    name: str
+    start_line: int
+    end_line: Optional[int]
+    keywords: List[str]
+    content: List[str]
+    line_start: int = 0  # Compatibility alias for start_line, set dynamically
+
+
+class NwchemParser:
+    """Parser for NWChem input files."""
+
+    SECTION_KEYWORDS = {
+        "geometry",
+        "basis",
+        "scf",
+        "dft",
+        "mp2",
+        "ccsd",
+        "ccsd(t)",
+        "ecp",
+        "so",
+        "tce",
+        "mcscf",
+        "selci",
+        "hessian",
+        "vib",
+        "property",
+        "rt_tddft",
+        "pspw",
+        "band",
+        "paw",
+        "ofpw",
+        "bq",
+        "cons",
+    }
+
+    TOP_LEVEL_KEYWORDS = {
+        "start",
+        "restart",
+        "title",
+        "echo",
+        "set",
+        "unset",
+        "stop",
+        "task",
+        "charge",
+        "memory",
+        "permanent_dir",
+        "scratch_dir",
+        "print",
+    }
+
+    def __init__(self, source: str):
+        """Initialize parser with source text."""
+        self.source = source
+        self.lines = source.splitlines()
+        self.sections: Dict[str, List[NWchemSection]] = {}
+        self._parse_sections()
+
+    def _parse_sections(self) -> None:
+        """Parse all sections from the source."""
+        current_section: Optional[NWchemSection] = None
+        section_keywords: List[str] = []
+        section_content: List[str] = []
+
+        for i, line in enumerate(self.lines):
+            stripped = line.strip().lower()
+
+            if not stripped or stripped.startswith("#"):
+                if current_section:
+                    section_content.append(line)
+                continue
+
+            parts = stripped.split()
+            if parts[0] in self.SECTION_KEYWORDS:
+                if current_section:
+                    current_section.end_line = i - 1
+                    current_section.content = section_content.copy()
+                    current_section.keywords = section_keywords.copy()
+                    if current_section.name not in self.sections:
+                        self.sections[current_section.name] = []
+                    self.sections[current_section.name].append(current_section)
+
+                section_name = parts[0]
+                section_keywords = []
+                section_content = [line]
+                current_section = NWchemSection(
+                    name=section_name,
+                    start_line=i,
+                    end_line=None,
+                    keywords=[],
+                    content=[],
+                )
+
+            elif stripped == "end" and current_section:
+                section_content.append(line)
+                current_section.end_line = i
+                current_section.content = section_content.copy()
+                current_section.keywords = section_keywords.copy()
+                if current_section.name not in self.sections:
+                    self.sections[current_section.name] = []
+                self.sections[current_section.name].append(current_section)
+                current_section = None
+                section_keywords = []
+                section_content = []
+
+            else:
+                if current_section:
+                    section_content.append(line)
+                    if parts:
+                        first_word = parts[0]
+                        if not first_word.startswith("#"):
+                            section_keywords.append(first_word)
+
+        if current_section:
+            current_section.end_line = len(self.lines) - 1
+            current_section.content = section_content.copy()
+            current_section.keywords = section_keywords.copy()
+            if current_section.name not in self.sections:
+                self.sections[current_section.name] = []
+            self.sections[current_section.name].append(current_section)
+
+    def get_section_at_line(self, line_number: int) -> Optional[str]:
+        """Get the section name at a specific line number."""
+        for section_name, sections in self.sections.items():
+            for section in sections:
+                end_line = section.end_line if section.end_line is not None else line_number
+                if section.start_line <= line_number <= end_line:
+                    return section_name
+        return None
+
+    def get_context(self, line_number: int, column: int) -> ParseContext:
+        """Get parsing context at a specific position."""
+        if line_number < 0 or line_number >= len(self.lines):
+            return ParseContext(
+                line_number=line_number,
+                column=column,
+                current_section=None,
+                section_stack=[],
+                line_content="",
+                word_at_cursor="",
+                is_in_block=False,
+            )
+
+        line_content = self.lines[line_number]
+        current_section = self.get_section_at_line(line_number)
+        section_stack: List[str] = []
+        if current_section:
+            section_stack.append(current_section)
+
+        word_at_cursor = self._get_word_at_position(line_content, column)
+        is_in_block = current_section is not None
+
+        return ParseContext(
+            line_number=line_number,
+            column=column,
+            current_section=current_section,
+            section_stack=section_stack,
+            line_content=line_content,
+            word_at_cursor=word_at_cursor,
+            is_in_block=is_in_block,
+        )
+
+    def _get_word_at_position(self, line: str, column: int) -> str:
+        """Extract the word at a specific column position."""
+        if not line or column < 0 or column > len(line):
+            return ""
+
+        start = column
+        end = column
+
+        while start > 0 and line[start - 1].isalnum():
+            start -= 1
+
+        while end < len(line) and line[end].isalnum():
+            end += 1
+
+        return line[start:end]
+
+    def get_completion_context(self, line_number: int, column: int) -> Dict[str, Any]:
+        """Get context information for completion requests."""
+        context = self.get_context(line_number, column)
+        line_content = context.line_content.lstrip().lower()
+
+        completion_type = "top_level"
+
+        if context.current_section:
+            completion_type = context.current_section
+        elif line_content.startswith("task"):
+            completion_type = "task_operation"
+        elif line_content.startswith("basis") or "library" in line_content:
+            completion_type = "basis_set"
+        elif line_content.startswith("dft") or line_content.startswith("xc"):
+            completion_type = "dft_functional"
+
+        return {
+            "type": completion_type,
+            "section": context.current_section,
+            "word": context.word_at_cursor,
+            "line": line_content,
+            "in_block": context.is_in_block,
+        }
+
+    def get_all_sections(self) -> List[str]:
+        """Get list of all section names."""
+        return list(self.sections.keys())
+
+    def get_section_content(self, section_name: str) -> List[NWchemSection]:
+        """Get all instances of a section."""
+        return self.sections.get(section_name, [])
+
+    def is_valid_syntax(self) -> Tuple[bool, List[Tuple[int, str]]]:
+        """Check if the input file has valid syntax."""
+        errors: List[Tuple[int, str]] = []
+        open_sections: List[Tuple[str, int]] = []
+
+        for i, line in enumerate(self.lines):
+            stripped = line.strip().lower()
+
+            if not stripped or stripped.startswith("#"):
+                continue
+
+            parts = stripped.split()
+            if not parts:
+                continue
+
+            keyword = parts[0]
+
+            if keyword in self.SECTION_KEYWORDS:
+                open_sections.append((keyword, i))
+
+            elif keyword == "end":
+                if not open_sections:
+                    errors.append((i, "Unexpected 'end' keyword (no matching section start)"))
+                else:
+                    open_sections.pop()
+
+        for section_name, start_line in open_sections:
+            errors.append((start_line, f"Unclosed section: '{section_name}'"))
+
+        return len(errors) == 0, errors
+
+    def parse(self) -> list[Any]:
+        """Parse and return all sections as blocks."""
+        blocks: list[Any] = []
+        for section_name, sections in self.sections.items():
+            for section in sections:
+                # Add line_start attribute for compatibility
+                if not hasattr(section, "line_start"):
+                    section.line_start = section.start_line
+                if not hasattr(section, "name"):
+                    section.name = section_name
+                blocks.append(section)
+
+        for index, line in enumerate(self.lines):
+            parts = line.strip().lower().split()
+            if parts and parts[0] == "task":
+                task = NWchemSection(
+                    name="task",
+                    start_line=index,
+                    end_line=index,
+                    keywords=parts[1:],
+                    content=[line],
+                )
+                task.line_start = index + 1
+                blocks.append(task)
+        return blocks
+
+    def validate(self) -> list[dict[str, Any]]:
+        """Validate and return errors as list of dicts."""
+        is_valid, errors = self.is_valid_syntax()
+        result: list[dict[str, Any]] = []
+        for line, message in errors:
+            result.append({"line": line, "column": 0, "message": message})
+        return result
+
+
+def parse_nwchem_source(source: str) -> NwchemParser:
+    """Parse NWChem input source."""
+    return NwchemParser(source)
+
+
+def get_line_keywords(line: str) -> List[str]:
+    """Extract keywords from a line."""
+    stripped = line.strip().lower()
+    if not stripped or stripped.startswith("#"):
+        return []
+
+    parts = stripped.split()
+    return parts

--- a/raw/assets/water_dft.nw
+++ b/raw/assets/water_dft.nw
@@ -1,0 +1,24 @@
+# Water molecule - DFT geometry optimization
+# Example NWChem input file
+
+start water
+
+title "Water molecule DFT/B3LYP geometry optimization"
+
+geometry units angstroms
+  O  0.000000  0.000000  0.000000
+  H  0.000000  0.790000  0.580000
+  H  0.000000 -0.790000  0.580000
+end
+
+basis spherical
+  * library 6-31G*
+end
+
+dft
+  xc b3lyp
+  grid fine
+  convergence energy 1e-8
+end
+
+task dft optimize

--- a/src/nwchem_lsp/features/agent_api.py
+++ b/src/nwchem_lsp/features/agent_api.py
@@ -3,16 +3,256 @@
 Provides structured JSON endpoints for Claude Code, OpenCode, Codex,
 and other agent workflows. Endpoints expose diagnostics, symbols,
 hover information, and document structure without requiring LSP protocol.
+
+Capability issues implemented:
+
+- #65: ``describe_domain_language()`` -- NWChem input language description
+- #66: ``lookup_section()``, ``lookup_keyword()`` -- schema lookup
+- #67: ``get_examples()``, ``next_token_suggestions()`` -- examples and guidance
+- #74: ``parse_log()``, ``parse_nwchem_output()`` -- output/log diagnostics
+- #84: ``get_rule_manifest()``, ``openqc_smoke()`` -- OpenQC smoke test
 """
 
 from __future__ import annotations
 
 import json
+import re
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from ..data.keywords import (
+    ALL_KEYWORDS,
+    BASIS_SETS,
+    DFT_FUNCTIONALS,
+    ELEMENTS,
+    TASK_OPERATIONS,
+    TASK_THEORIES,
+    TOP_LEVEL_SECTIONS,
+)
 from .diagnostic import DiagnosticProvider
-from .lint import NwchemLintProvider
+from .lint import NwchemLintProvider, RULE_DESCRIPTIONS
+
+
+# ------------------------------------------------------------------
+# NWChem domain language description (#65)
+# ------------------------------------------------------------------
+
+_DOMAIN_LANGUAGE_DESCRIPTION: Dict[str, Any] = {
+    "language": "nwchem",
+    "file_extensions": [".nw", ".nwchem"],
+    "description": (
+        "NWChem input format for computational chemistry. Files consist of "
+        "top-level directives (title, charge, memory, etc.) and block "
+        "sections (geometry, basis, scf, dft, mp2, ccds, etc.) delimited "
+        "by END keywords. Task directives specify the calculation type."
+    ),
+    "sections": [
+        {
+            "name": "geometry",
+            "required": True,
+            "description": "Molecular geometry specification with atom coordinates",
+            "keywords": ["units", "angstroms", "bohr", "autosym", "noautoz"],
+        },
+        {
+            "name": "basis",
+            "required": True,
+            "description": "Basis set specification per element",
+            "keywords": ["spherical", "cartesian", "library", "file"],
+        },
+        {
+            "name": "scf",
+            "required": False,
+            "description": "Self-Consistent Field (Hartree-Fock) options",
+            "keywords": ["singlet", "doublet", "triplet", "rhf", "uhf", "rohf",
+                         "maxiter", "thresh", "direct", "semidirect"],
+        },
+        {
+            "name": "dft",
+            "required": False,
+            "description": "Density Functional Theory options",
+            "keywords": ["xc", "grid", "convergence", "iterations", "direct",
+                         "noio", "odft", "cdft", "mult"],
+        },
+        {
+            "name": "mp2",
+            "required": False,
+            "description": "Second-order perturbation theory options",
+            "keywords": ["tight", "freeze", "ri", "cd"],
+        },
+        {
+            "name": "ccsd",
+            "required": False,
+            "description": "Coupled Cluster Singles and Doubles options",
+            "keywords": ["tce", "freeze", "thresh", "maxiter"],
+        },
+        {
+            "name": "tce",
+            "required": False,
+            "description": "Tensor Contraction Engine options",
+            "keywords": ["freeze", "thresh", "maxiter"],
+        },
+    ],
+    "task_directives": {
+        "syntax": "task <theory> <operation>",
+        "theories": sorted(TASK_THEORIES),
+        "operations": sorted(TASK_OPERATIONS),
+    },
+    "common_functionals": sorted(DFT_FUNCTIONALS)[:20],
+    "common_basis_sets": sorted(BASIS_SETS)[:20],
+}
+
+# ------------------------------------------------------------------
+# NWChem input examples (#67)
+# ------------------------------------------------------------------
+
+_NWCHEM_EXAMPLES: List[Dict[str, str]] = [
+    {
+        "name": "HF single-point energy",
+        "source": (
+            'title "Water HF energy"\n'
+            "geometry units angstroms\n"
+            "  O  0.0  0.0  0.0\n"
+            "  H  0.0  0.8  0.6\n"
+            "  H  0.0 -0.8  0.6\n"
+            "end\n"
+            "\n"
+            "basis\n"
+            "  * library 6-31g*\n"
+            "end\n"
+            "\n"
+            "task scf energy\n"
+        ),
+    },
+    {
+        "name": "DFT geometry optimization",
+        "source": (
+            'title "Water DFT optimization"\n'
+            "geometry units angstroms\n"
+            "  O  0.0  0.0  0.0\n"
+            "  H  0.0  0.8  0.6\n"
+            "  H  0.0 -0.8  0.6\n"
+            "end\n"
+            "\n"
+            "basis\n"
+            "  * library cc-pvdz\n"
+            "end\n"
+            "\n"
+            "dft\n"
+            "  xc b3lyp\n"
+            "  grid fine\n"
+            "end\n"
+            "\n"
+            "task dft optimize\n"
+        ),
+    },
+    {
+        "name": "MP2 correlation energy",
+        "source": (
+            'title "Water MP2"\n'
+            "geometry units angstroms\n"
+            "  O  0.0  0.0  0.0\n"
+            "  H  0.0  0.8  0.6\n"
+            "  H  0.0 -0.8  0.6\n"
+            "end\n"
+            "\n"
+            "basis\n"
+            "  * library aug-cc-pvdz\n"
+            "end\n"
+            "\n"
+            "mp2\n"
+            "  freeze atomic\n"
+            "end\n"
+            "\n"
+            "task mp2 energy\n"
+        ),
+    },
+    {
+        "name": "CCSD(T) single-point",
+        "source": (
+            'title "Water CCSD(T)"\n'
+            "geometry units angstroms\n"
+            "  O  0.0  0.0  0.0\n"
+            "  H  0.0  0.8  0.6\n"
+            "  H  0.0 -0.8  0.6\n"
+            "end\n"
+            "\n"
+            "basis\n"
+            "  * library cc-pvtz\n"
+            "end\n"
+            "\n"
+            "ccsd\n"
+            "  freeze atomic\n"
+            "  thresh 1e-6\n"
+            "end\n"
+            "\n"
+            "task ccsd energy\n"
+        ),
+    },
+]
+
+# ------------------------------------------------------------------
+# Log output pattern matchers for parse_log (#74)
+# ------------------------------------------------------------------
+
+_LOG_PATTERNS: List[Dict[str, Any]] = [
+    {
+        "pattern": r"SCF failed to converge",
+        "code": "NWCHEM-E044",
+        "severity": "error",
+        "message": "SCF calculation did not converge within iteration limit",
+    },
+    {
+        "pattern": r"RuntimeError|FATAL ERROR|Aborting",
+        "code": "NWCHEM-E044",
+        "severity": "error",
+        "message": "NWChem runtime error detected",
+    },
+    {
+        "pattern": r"Insufficient memory",
+        "code": "NWCHEM-E044",
+        "severity": "error",
+        "message": "Insufficient memory for calculation",
+    },
+    {
+        "pattern": r"could not find basis set",
+        "code": "NWCHEM-E044",
+        "severity": "error",
+        "message": "Basis set not found in library",
+    },
+    {
+        "pattern": r"ga_exit\b|djrfATAL|general error",
+        "code": "NWCHEM-E044",
+        "severity": "error",
+        "message": "Global Arrays / NWChem internal error",
+    },
+    {
+        "pattern": r"Total SCF energy\s*=\s*([-\d.E+]+)",
+        "code": "NWCHEM-INFO-001",
+        "severity": "info",
+        "message": "SCF energy",
+        "extract": True,
+    },
+    {
+        "pattern": r"Total DFT energy\s*=\s*([-\d.E+]+)",
+        "code": "NWCHEM-INFO-002",
+        "severity": "info",
+        "message": "DFT energy",
+        "extract": True,
+    },
+    {
+        "pattern": r"Optimization converged",
+        "code": "NWCHEM-INFO-003",
+        "severity": "info",
+        "message": "Geometry optimization converged",
+    },
+    {
+        "pattern": r"SCF.converged\s*=\s*TRUE",
+        "code": "NWCHEM-INFO-004",
+        "severity": "info",
+        "message": "SCF converged",
+    },
+]
 
 
 @dataclass
@@ -41,17 +281,28 @@ class AgentAPISnapshot:
 
 
 class AgentAPIProvider:
-    """Provides machine-readable code intelligence for AI agents."""
+    """Provides machine-readable code intelligence for AI agents.
+
+    Capability methods:
+
+    - :meth:`describe_domain_language` (#65)
+    - :meth:`lookup_section`, :meth:`lookup_keyword` (#66)
+    - :meth:`get_examples`, :meth:`next_token_suggestions` (#67)
+    - :meth:`parse_log`, :meth:`parse_nwchem_output` (#74)
+    - :meth:`get_rule_manifest`, :meth:`openqc_smoke` (#84)
+    """
 
     def __init__(
         self,
         diagnostic_provider: Optional[DiagnosticProvider] = None,
         lint_provider: Optional[NwchemLintProvider] = None,
-        
     ) -> None:
         self._diagnostic = diagnostic_provider
         self._lint = lint_provider
-        
+
+    # ------------------------------------------------------------------
+    # Existing snapshot API
+    # ------------------------------------------------------------------
 
     def get_snapshot(
         self,
@@ -100,15 +351,26 @@ class AgentAPIProvider:
             if stripped.startswith("title ") or stripped == "title":
                 outline.append({"type": "title", "line": i, "text": stripped})
             elif stripped.startswith("start "):
-                outline.append({"type": "module_start", "line": i, "name": stripped.split()[1] if len(stripped.split()) > 1 else ""})
+                outline.append(
+                    {
+                        "type": "module_start",
+                        "line": i,
+                        "name": (
+                            stripped.split()[1] if len(stripped.split()) > 1 else ""
+                        ),
+                    }
+                )
             elif stripped.startswith("task "):
                 outline.append({"type": "task", "line": i, "text": stripped})
             elif not stripped.startswith("end") and (
-                stripped in ("geometry", "basis", "scf", "dft", "mp2", "ccsd", "tce")
+                stripped
+                in ("geometry", "basis", "scf", "dft", "mp2", "ccsd", "tce")
                 or stripped.startswith("geometry ")
                 or stripped.startswith("basis ")
             ):
-                outline.append({"type": "section", "line": i, "name": stripped.split()[0]})
+                outline.append(
+                    {"type": "section", "line": i, "name": stripped.split()[0]}
+                )
 
         return AgentAPISnapshot(
             uri=uri,
@@ -148,3 +410,424 @@ class AgentAPIProvider:
             },
             indent=2,
         )
+
+    # ------------------------------------------------------------------
+    # Capability #65: Domain language description
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def describe_domain_language() -> Dict[str, Any]:
+        """Return a structured description of the NWChem input language.
+
+        The description covers file extensions, sections, keywords,
+        task directive syntax, common functionals and basis sets.
+
+        Returns:
+            Dictionary with full NWChem language schema.
+        """
+        return _DOMAIN_LANGUAGE_DESCRIPTION.copy()
+
+    # ------------------------------------------------------------------
+    # Capability #66: Schema lookup
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def lookup_section(name: str) -> Optional[Dict[str, Any]]:
+        """Look up a section by name.
+
+        Args:
+            name: Section name (case-insensitive).
+
+        Returns:
+            Dictionary with section metadata or None if not found.
+        """
+        key = name.lower()
+        for section_info in _DOMAIN_LANGUAGE_DESCRIPTION["sections"]:
+            if section_info["name"] == key:
+                return {
+                    "name": section_info["name"],
+                    "required": section_info["required"],
+                    "description": section_info["description"],
+                    "keywords": section_info["keywords"],
+                }
+        # Also check top-level keywords
+        from ..data.keywords import TOP_LEVEL_KEYWORDS
+
+        kw_info = TOP_LEVEL_KEYWORDS.get(key)
+        if kw_info:
+            return {
+                "name": kw_info.name,
+                "required": kw_info.required,
+                "description": kw_info.description,
+                "keywords": kw_info.arguments or [],
+            }
+        return None
+
+    @staticmethod
+    def lookup_keyword(section: str, keyword: str) -> Optional[Dict[str, Any]]:
+        """Look up a keyword within a section.
+
+        Args:
+            section: Section name (case-insensitive).
+            keyword: Keyword name (case-insensitive).
+
+        Returns:
+            Dictionary with keyword metadata or None if not found.
+        """
+        from ..data.keywords import get_keyword_info, KeywordInfo
+
+        info: Optional[KeywordInfo] = get_keyword_info(keyword.lower(), section.lower())
+        if info is None:
+            return None
+        return {
+            "name": info.name,
+            "section": info.section,
+            "description": info.description,
+            "required": info.required,
+            "arguments": info.arguments or [],
+            "example": info.example,
+            "deprecated": info.deprecated,
+        }
+
+    # ------------------------------------------------------------------
+    # Capability #67: Examples and token suggestions
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def get_examples() -> List[Dict[str, str]]:
+        """Return curated NWChem input file examples.
+
+        Returns:
+            List of example dicts, each with ``name`` and ``source``.
+        """
+        return [ex.copy() for ex in _NWCHEM_EXAMPLES]
+
+    @staticmethod
+    def next_token_suggestions(
+        context: str,
+        prefix: str = "",
+    ) -> List[Dict[str, str]]:
+        """Suggest the next tokens given a parsing context.
+
+        Args:
+            context: Current context indicator. One of
+                ``"top_level"``, ``"task_theory"``, ``"task_operation"``,
+                ``"basis_set"``, ``"dft_functional"``, or a section name.
+            prefix: Optional prefix to filter suggestions.
+
+        Returns:
+            List of suggestion dicts with ``text`` and ``description``.
+        """
+        suggestions: List[Dict[str, str]] = []
+        prefix_lower = prefix.lower()
+
+        if context == "top_level":
+            for sec in TOP_LEVEL_SECTIONS:
+                if sec.startswith(prefix_lower):
+                    suggestions.append(
+                        {"text": sec, "description": f"Section: {sec}"}
+                    )
+            suggestions.append(
+                {"text": "task", "description": "Execute a computational task"}
+            )
+            suggestions.append(
+                {"text": "title", "description": "Set calculation title"}
+            )
+            suggestions.append(
+                {"text": "charge", "description": "Set molecular charge"}
+            )
+            suggestions.append(
+                {"text": "memory", "description": "Set memory limits"}
+            )
+
+        elif context == "task_theory":
+            for theory in sorted(TASK_THEORIES):
+                if theory.startswith(prefix_lower):
+                    suggestions.append(
+                        {"text": theory, "description": f"Theory: {theory}"}
+                    )
+
+        elif context == "task_operation":
+            for op in sorted(TASK_OPERATIONS):
+                if op.startswith(prefix_lower):
+                    suggestions.append(
+                        {"text": op, "description": f"Operation: {op}"}
+                    )
+
+        elif context == "basis_set":
+            for bs in sorted(BASIS_SETS):
+                if bs.lower().startswith(prefix_lower):
+                    suggestions.append(
+                        {"text": bs, "description": f"Basis set: {bs}"}
+                    )
+
+        elif context == "dft_functional":
+            for func in sorted(DFT_FUNCTIONALS):
+                if func.lower().startswith(prefix_lower):
+                    suggestions.append(
+                        {"text": func, "description": f"Functional: {func}"}
+                    )
+
+        else:
+            # Section-specific keyword suggestions
+            section_key = context.lower()
+            section_dict = ALL_KEYWORDS.get(section_key, {})
+            for kw_name, kw_info in section_dict.items():
+                if kw_name.startswith(prefix_lower):
+                    suggestions.append(
+                        {"text": kw_name, "description": kw_info.description}
+                    )
+
+        return suggestions
+
+    # ------------------------------------------------------------------
+    # Capability #74: Log / output parser
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def parse_log(text: str) -> List[Dict[str, Any]]:
+        """Parse NWChem log/output text for errors and key information.
+
+        Args:
+            text: Raw NWChem output/log file content.
+
+        Returns:
+            List of finding dicts with ``line``, ``code``, ``severity``,
+            ``message``, and optionally ``value``.
+        """
+        findings: List[Dict[str, Any]] = []
+        lines = text.splitlines()
+
+        for line_num, line in enumerate(lines):
+            for entry in _LOG_PATTERNS:
+                match = re.search(entry["pattern"], line, re.IGNORECASE)
+                if match:
+                    finding: Dict[str, Any] = {
+                        "line": line_num,
+                        "code": entry["code"],
+                        "severity": entry["severity"],
+                        "message": entry["message"],
+                    }
+                    if entry.get("extract") and match.lastindex:
+                        finding["value"] = match.group(1)
+                    findings.append(finding)
+
+        return findings
+
+    @staticmethod
+    def parse_nwchem_output(path: str) -> List[Dict[str, Any]]:
+        """Parse an NWChem output file from a filesystem path.
+
+        Args:
+            path: Filesystem path to the NWChem output file.
+
+        Returns:
+            List of finding dicts (same as :meth:`parse_log`).
+
+        Raises:
+            FileNotFoundError: If the file does not exist.
+        """
+        p = Path(path)
+        if not p.exists():
+            raise FileNotFoundError(f"NWChem output file not found: {path}")
+        text = p.read_text(errors="replace")
+        return AgentAPIProvider.parse_log(text)
+
+    # ------------------------------------------------------------------
+    # Capability #84: Rule manifest and OpenQC smoke test
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def get_rule_manifest() -> Dict[str, Any]:
+        """Return the full rule code catalog with descriptions.
+
+        Returns:
+            Dictionary mapping rule codes to their descriptions,
+            plus metadata about the NWChem LSP implementation.
+        """
+        return {
+            "provider": "nwchem-lsp",
+            "language": "nwchem",
+            "version": "1.0.0",
+            "rules": {
+                code: desc for code, desc in RULE_DESCRIPTIONS.items()
+            },
+            "rule_count": len(RULE_DESCRIPTIONS),
+            "categories": {
+                "syntax": [
+                    c for c in RULE_DESCRIPTIONS if c.startswith("NW1")
+                ],
+                "schema": [
+                    c for c in RULE_DESCRIPTIONS if c.startswith("NW2")
+                ],
+                "best_practice": [
+                    c for c in RULE_DESCRIPTIONS if c.startswith("NW3")
+                ],
+                "issue_mapped": [
+                    c for c in RULE_DESCRIPTIONS if c.startswith("NWCHEM-")
+                ],
+            },
+        }
+
+    @staticmethod
+    def openqc_smoke() -> Dict[str, Any]:
+        """Run a lightweight smoke test for OpenQC integration.
+
+        Validates that the NWChem LSP provider can be instantiated and
+        that core APIs return expected shapes.
+
+        Returns:
+            Dictionary with ``status`` (``"pass"`` or ``"fail"``),
+            ``checks``, and ``error`` (if any).
+        """
+        checks: List[Dict[str, Any]] = []
+
+        # Check 1: Lint provider instantiation
+        try:
+            lint = NwchemLintProvider()
+            diags = lint.lint("geometry\n  H 0 0 0\nend\nbasis\n  * library 6-31g\nend\ntask scf energy\n")
+            checks.append(
+                {
+                    "name": "lint_provider",
+                    "status": "pass",
+                    "diagnostic_count": len(diags),
+                }
+            )
+        except Exception as exc:
+            checks.append(
+                {"name": "lint_provider", "status": "fail", "error": str(exc)}
+            )
+
+        # Check 2: Domain language description
+        try:
+            desc = AgentAPIProvider.describe_domain_language()
+            has_sections = "sections" in desc and len(desc["sections"]) > 0
+            checks.append(
+                {
+                    "name": "describe_domain_language",
+                    "status": "pass" if has_sections else "fail",
+                    "section_count": len(desc.get("sections", [])),
+                }
+            )
+        except Exception as exc:
+            checks.append(
+                {
+                    "name": "describe_domain_language",
+                    "status": "fail",
+                    "error": str(exc),
+                }
+            )
+
+        # Check 3: Schema lookup
+        try:
+            geo = AgentAPIProvider.lookup_section("geometry")
+            ok = geo is not None and geo.get("required") is True
+            checks.append(
+                {
+                    "name": "lookup_section",
+                    "status": "pass" if ok else "fail",
+                }
+            )
+        except Exception as exc:
+            checks.append(
+                {"name": "lookup_section", "status": "fail", "error": str(exc)}
+            )
+
+        # Check 4: Keyword lookup
+        try:
+            xc = AgentAPIProvider.lookup_keyword("dft", "xc")
+            ok = xc is not None and "description" in xc
+            checks.append(
+                {
+                    "name": "lookup_keyword",
+                    "status": "pass" if ok else "fail",
+                }
+            )
+        except Exception as exc:
+            checks.append(
+                {"name": "lookup_keyword", "status": "fail", "error": str(exc)}
+            )
+
+        # Check 5: Examples
+        try:
+            examples = AgentAPIProvider.get_examples()
+            ok = len(examples) > 0 and all("source" in e for e in examples)
+            checks.append(
+                {
+                    "name": "get_examples",
+                    "status": "pass" if ok else "fail",
+                    "example_count": len(examples),
+                }
+            )
+        except Exception as exc:
+            checks.append(
+                {"name": "get_examples", "status": "fail", "error": str(exc)}
+            )
+
+        # Check 6: Token suggestions
+        try:
+            suggestions = AgentAPIProvider.next_token_suggestions("task_theory")
+            ok = len(suggestions) > 0
+            checks.append(
+                {
+                    "name": "next_token_suggestions",
+                    "status": "pass" if ok else "fail",
+                    "suggestion_count": len(suggestions),
+                }
+            )
+        except Exception as exc:
+            checks.append(
+                {
+                    "name": "next_token_suggestions",
+                    "status": "fail",
+                    "error": str(exc),
+                }
+            )
+
+        # Check 7: Log parser
+        try:
+            findings = AgentAPIProvider.parse_log(
+                "SCF failed to converge after 100 iterations\n"
+                "Total SCF energy = -76.0234\n"
+            )
+            ok = len(findings) >= 2
+            checks.append(
+                {
+                    "name": "parse_log",
+                    "status": "pass" if ok else "fail",
+                    "finding_count": len(findings),
+                }
+            )
+        except Exception as exc:
+            checks.append(
+                {"name": "parse_log", "status": "fail", "error": str(exc)}
+            )
+
+        # Check 8: Rule manifest
+        try:
+            manifest = AgentAPIProvider.get_rule_manifest()
+            ok = "rules" in manifest and len(manifest["rules"]) > 0
+            checks.append(
+                {
+                    "name": "get_rule_manifest",
+                    "status": "pass" if ok else "fail",
+                    "rule_count": len(manifest.get("rules", {})),
+                }
+            )
+        except Exception as exc:
+            checks.append(
+                {
+                    "name": "get_rule_manifest",
+                    "status": "fail",
+                    "error": str(exc),
+                }
+            )
+
+        all_passed = all(c["status"] == "pass" for c in checks)
+        return {
+            "status": "pass" if all_passed else "fail",
+            "checks": checks,
+            "check_count": len(checks),
+            "passed": sum(1 for c in checks if c["status"] == "pass"),
+            "failed": sum(1 for c in checks if c["status"] == "fail"),
+        }

--- a/src/nwchem_lsp/features/lint.py
+++ b/src/nwchem_lsp/features/lint.py
@@ -71,11 +71,34 @@ RULE_DESCRIPTIONS: dict[str, str] = {
     "NW2009": "Unknown top-level directive",
     "NW2010": "Duplicate section (only one allowed)",
     "NW2011": "Keyword not valid in this section",
+    "NW2012": "Geometry section has malformed atom coordinates",
     # -- Best-practice / hints (3000-3999) --
     "NW3001": "SCF maxiter outside typical range (1-500)",
     "NW3002": "Convergence threshold unusually loose",
     "NW3003": "Duplicate task directive",
     "NW3004": "Unusual charge/multiplicity combination",
+    # -- Issue-mapped codes (NWCHEM-Exxxx / NWCHEM-Wxxxx) --
+    "NWCHEM-E040": "Unknown section or directive name",
+    "NWCHEM-W040": "Same section declared twice",
+    "NWCHEM-E041": "Task directive missing operation (energy/optimize/etc)",
+    "NWCHEM-E042": "Task theory not in known set",
+    "NWCHEM-W041": "Basis set not recognized",
+    "NWCHEM-W042": "DFT functional not recognized",
+    "NWCHEM-W043": "Loose SCF convergence threshold",
+    "NWCHEM-E043": "Geometry section has errors",
+    "NWCHEM-E044": "Runtime parse error from NWChem log output",
+}
+
+# Mapping from NW code to issue-mapped NWCHEM code for dual emission
+_NW_TO_NWCHEM_MAP: dict[str, str] = {
+    "NW2009": "NWCHEM-E040",
+    "NW2010": "NWCHEM-W040",
+    "NW2006": "NWCHEM-E041",
+    "NW2005": "NWCHEM-E042",
+    "NW2007": "NWCHEM-W041",
+    "NW2008": "NWCHEM-W042",
+    "NW3002": "NWCHEM-W043",
+    "NW2012": "NWCHEM-E043",
 }
 
 # Sections that may appear at most once
@@ -169,13 +192,22 @@ class NwchemLintProvider:
         self._check_basis_references(sections, lines, diagnostics)
         self._check_dft_functionals(sections, lines, diagnostics)
         self._check_top_level_directives(lines, sections, diagnostics)
+        self._check_geometry_malformed(sections, lines, diagnostics)
+        self._check_task_missing_operation(lines, diagnostics)
 
         # Best-practice checks
         self._check_scf_maxiter(sections, lines, diagnostics)
         self._check_convergence_thresh(sections, lines, diagnostics)
         self._check_duplicate_tasks(lines, diagnostics)
 
+        # Append NWCHEM-prefixed dual codes
+        self._append_nwchem_codes(diagnostics)
+
         return diagnostics
+
+    def check(self, text: str) -> list[Diagnostic]:
+        """Alias for :meth:`lint` used by the agent API layer."""
+        return self.lint(text)
 
     # ------------------------------------------------------------------
     # Syntax checks (NW1xxx)
@@ -664,6 +696,129 @@ class NwchemLintProvider:
     # ------------------------------------------------------------------
     # Helpers
     # ------------------------------------------------------------------
+
+    def _append_nwchem_codes(self, diagnostics: list[Diagnostic]) -> None:
+        """Append NWCHEM-prefixed dual codes for matched NW codes.
+
+        For each diagnostic whose code appears in the NW-to-NWCHEM mapping,
+        emit a second diagnostic with the mapped NWCHEM code so that agent
+        consumers see both the internal NW code and the issue-tracked code.
+        """
+        for diag in list(diagnostics):
+            nw_code = str(diag.code) if diag.code else ""
+            nwchem_code = _NW_TO_NWCHEM_MAP.get(nw_code)
+            if nwchem_code:
+                diagnostics.append(
+                    Diagnostic(
+                        range=diag.range,
+                        message=diag.message,
+                        severity=diag.severity,
+                        source=diag.source,
+                        code=nwchem_code,
+                    )
+                )
+
+    def _check_geometry_malformed(
+        self,
+        sections: dict[str, list[Any]],
+        lines: list[str],
+        diagnostics: list[Diagnostic],
+    ) -> None:
+        """NW2012 / NWCHEM-E043: Detect malformed atom coordinate lines in geometry."""
+        if "geometry" not in sections:
+            return
+
+        for section_obj in sections["geometry"]:
+            for idx, content_line in enumerate(section_obj.content):
+                stripped = content_line.strip()
+                lower = stripped.lower()
+                if not lower or lower.startswith("#") or lower == "end":
+                    continue
+
+                parts = lower.split()
+                if not parts:
+                    continue
+
+                # Skip the section header line itself
+                if parts[0] == "geometry":
+                    continue
+
+                # Skip known geometry sub-directives
+                if parts[0] in {
+                    "units", "angstroms", "bohr", "au", "nocenter",
+                    "center", "autosym", "noautoz", "system",
+                }:
+                    continue
+
+                # Check for atom coordinate lines: Element x y z
+                # If first token looks like an element, validate coords
+                if parts[0] in _ELEMENTS_LOWER:
+                    # Need at least 4 tokens: element x y z
+                    if len(parts) < 4:
+                        line_num = section_obj.start_line + idx
+                        col = _find_col(content_line, parts[0])
+                        diagnostics.append(
+                            _diag(
+                                line_num,
+                                col,
+                                col + len(parts[0]),
+                                f"Atom line for '{parts[0]}' has fewer than 3 coordinates",
+                                DiagnosticSeverity.Error,
+                                "NW2012",
+                            )
+                        )
+                        continue
+
+                    # Validate that coordinate tokens are numbers
+                    for coord_idx in range(1, min(4, len(parts))):
+                        try:
+                            float(parts[coord_idx])
+                        except ValueError:
+                            line_num = section_obj.start_line + idx
+                            col = _find_col(content_line, parts[coord_idx])
+                            diagnostics.append(
+                                _diag(
+                                    line_num,
+                                    col,
+                                    col + len(parts[coord_idx]),
+                                    f"Non-numeric coordinate '{parts[coord_idx]}' "
+                                    f"for atom '{parts[0]}'",
+                                    DiagnosticSeverity.Error,
+                                    "NW2012",
+                                )
+                            )
+
+    def _check_task_missing_operation(
+        self, lines: list[str], diagnostics: list[Diagnostic]
+    ) -> None:
+        """NWCHEM-E041: Task directive with no operation specified.
+
+        A valid task line is ``task <theory> <operation>``. If the operation
+        is missing (i.e. ``task dft`` with no third token), emit a warning
+        because NWChem will default to ``energy`` but the user likely wants
+        to be explicit.
+        """
+        for i, line in enumerate(lines):
+            stripped = line.strip().lower()
+            if not stripped.startswith("task") or stripped.startswith("#"):
+                continue
+
+            parts = stripped.split()
+            # parts[0]="task", parts[1]=theory, parts[2]=operation (optional)
+            if len(parts) == 2:
+                # Only theory, no operation
+                theory = parts[1]
+                if theory in _TASK_THEORIES_LOWER:
+                    col = _find_col(line, "task")
+                    diagnostics.append(
+                        _diag(
+                            i, col, col + len(line.lstrip()),
+                            f"Task directive for '{theory}' missing operation "
+                            f"(e.g. energy, optimize, gradient)",
+                            DiagnosticSeverity.Warning,
+                            "NWCHEM-E041",
+                        )
+                    )
 
     def _section_to_schema_key(self, section_name: str) -> str:
         """Map a parser section name to the keyword schema section key."""

--- a/tests/features/test_agent_api.py
+++ b/tests/features/test_agent_api.py
@@ -1,9 +1,26 @@
-"""Tests for the agent API provider."""
+"""Tests for the agent API provider.
+
+Covers capabilities:
+- #65: describe_domain_language
+- #66: lookup_section, lookup_keyword
+- #67: get_examples, next_token_suggestions
+- #74: parse_log, parse_nwchem_output
+- #84: get_rule_manifest, openqc_smoke
+"""
 
 import json
+import pathlib
+import tempfile
+
 import pytest
 
 from nwchem_lsp.features.agent_api import AgentAPIProvider, AgentAPISnapshot
+from nwchem_lsp.features.lint import NwchemLintProvider
+
+
+CAPABILITIES_FIXTURES_DIR = (
+    pathlib.Path(__file__).parent.parent / "fixtures" / "capabilities"
+)
 
 
 @pytest.fixture
@@ -11,9 +28,22 @@ def provider() -> AgentAPIProvider:
     return AgentAPIProvider()
 
 
+@pytest.fixture
+def provider_with_lint() -> AgentAPIProvider:
+    lint = NwchemLintProvider()
+    return AgentAPIProvider(lint_provider=lint)
+
+
+# ------------------------------------------------------------------
+# Existing snapshot tests
+# ------------------------------------------------------------------
+
+
 class TestAgentAPISnapshot:
     def test_to_json(self):
-        s = AgentAPISnapshot(uri="test.nw", diagnostics=[{"line": 0, "message": "test"}])
+        s = AgentAPISnapshot(
+            uri="test.nw", diagnostics=[{"line": 0, "message": "test"}]
+        )
         data = json.loads(s.to_json())
         assert data["uri"] == "test.nw"
         assert len(data["diagnostics"]) == 1
@@ -38,7 +68,9 @@ class TestAgentAPIProvider:
         assert len(snap.outline) > 0
 
     def test_outline_sections(self, provider: AgentAPIProvider):
-        source = "geometry\n  O 0 0 0\nend\nbasis\n  O library 6-31g\nend\n"
+        source = (
+            "geometry\n  O 0 0 0\nend\nbasis\n  O library 6-31g\nend\n"
+        )
         snap = provider.get_snapshot(source)
         sections = [o for o in snap.outline if o["type"] == "section"]
         section_names = [s["name"] for s in sections]
@@ -60,3 +92,484 @@ class TestAgentAPIProvider:
         snap = provider.get_snapshot("title test\n")
         assert snap.metadata["provider"] == "nwchem-lsp"
         assert "diagnostics" in snap.metadata["feature_count"]
+
+    def test_snapshot_with_lint_provider(
+        self, provider_with_lint: AgentAPIProvider
+    ):
+        source = (
+            "geometry\n  H 0 0 0\nend\n"
+            "basis\n  * library 6-31g\nend\n"
+            "task scf energy\n"
+        )
+        snap = provider_with_lint.get_snapshot(source)
+        assert snap.metadata["language"] == "nwchem"
+        assert isinstance(snap.diagnostics, list)
+
+
+# ------------------------------------------------------------------
+# Capability #65: describe_domain_language
+# ------------------------------------------------------------------
+
+
+class TestDescribeDomainLanguage:
+    """Tests for the describe_domain_language capability (#65)."""
+
+    def test_returns_dict(self, provider: AgentAPIProvider):
+        result = provider.describe_domain_language()
+        assert isinstance(result, dict)
+
+    def test_has_language(self, provider: AgentAPIProvider):
+        result = provider.describe_domain_language()
+        assert result["language"] == "nwchem"
+
+    def test_has_file_extensions(self, provider: AgentAPIProvider):
+        result = provider.describe_domain_language()
+        assert ".nw" in result["file_extensions"]
+
+    def test_has_description(self, provider: AgentAPIProvider):
+        result = provider.describe_domain_language()
+        assert "description" in result
+        assert len(result["description"]) > 0
+
+    def test_has_sections(self, provider: AgentAPIProvider):
+        result = provider.describe_domain_language()
+        assert "sections" in result
+        assert len(result["sections"]) >= 5
+        section_names = [s["name"] for s in result["sections"]]
+        assert "geometry" in section_names
+        assert "basis" in section_names
+        assert "scf" in section_names
+        assert "dft" in section_names
+
+    def test_has_task_directives(self, provider: AgentAPIProvider):
+        result = provider.describe_domain_language()
+        assert "task_directives" in result
+        assert "theories" in result["task_directives"]
+        assert "operations" in result["task_directives"]
+        assert "scf" in result["task_directives"]["theories"]
+        assert "energy" in result["task_directives"]["operations"]
+
+    def test_has_functionals_and_basis_sets(self, provider: AgentAPIProvider):
+        result = provider.describe_domain_language()
+        assert "common_functionals" in result
+        assert "common_basis_sets" in result
+        assert len(result["common_functionals"]) > 0
+        assert len(result["common_basis_sets"]) > 0
+
+
+# ------------------------------------------------------------------
+# Capability #66: lookup_section and lookup_keyword
+# ------------------------------------------------------------------
+
+
+class TestLookupSection:
+    """Tests for the lookup_section capability (#66)."""
+
+    def test_lookup_geometry(self, provider: AgentAPIProvider):
+        result = provider.lookup_section("geometry")
+        assert result is not None
+        assert result["name"] == "geometry"
+        assert result["required"] is True
+
+    def test_lookup_basis(self, provider: AgentAPIProvider):
+        result = provider.lookup_section("basis")
+        assert result is not None
+        assert result["name"] == "basis"
+        assert result["required"] is True
+
+    def test_lookup_scf(self, provider: AgentAPIProvider):
+        result = provider.lookup_section("scf")
+        assert result is not None
+        assert result["name"] == "scf"
+
+    def test_lookup_dft(self, provider: AgentAPIProvider):
+        result = provider.lookup_section("dft")
+        assert result is not None
+        assert result["name"] == "dft"
+
+    def test_lookup_case_insensitive(self, provider: AgentAPIProvider):
+        result = provider.lookup_section("GEOMETRY")
+        assert result is not None
+        assert result["name"] == "geometry"
+
+    def test_lookup_unknown_returns_none(self, provider: AgentAPIProvider):
+        result = provider.lookup_section("nonexistent_section")
+        assert result is None
+
+    def test_lookup_top_level_keyword(self, provider: AgentAPIProvider):
+        result = provider.lookup_section("memory")
+        assert result is not None
+        assert result["name"] == "memory"
+
+    def test_returns_copy(self, provider: AgentAPIProvider):
+        r1 = provider.lookup_section("geometry")
+        r2 = provider.lookup_section("geometry")
+        assert r1 == r2
+        r1["name"] = "modified"
+        assert r2["name"] == "geometry"
+
+
+class TestLookupKeyword:
+    """Tests for the lookup_keyword capability (#66)."""
+
+    def test_lookup_xc_in_dft(self, provider: AgentAPIProvider):
+        result = provider.lookup_keyword("dft", "xc")
+        assert result is not None
+        assert result["name"] == "xc"
+        assert result["section"] == "dft"
+        assert "B3LYP" in result.get("arguments", [])
+
+    def test_lookup_maxiter_in_scf(self, provider: AgentAPIProvider):
+        result = provider.lookup_keyword("scf", "maxiter")
+        assert result is not None
+        assert result["name"] == "maxiter"
+
+    def test_lookup_unknown_returns_none(self, provider: AgentAPIProvider):
+        result = provider.lookup_keyword("dft", "nonexistent_keyword")
+        assert result is None
+
+    def test_lookup_in_unknown_section_returns_none(
+        self, provider: AgentAPIProvider
+    ):
+        result = provider.lookup_keyword("nonexistent", "xc")
+        assert result is None
+
+    def test_lookup_returns_description(self, provider: AgentAPIProvider):
+        result = provider.lookup_keyword("dft", "grid")
+        assert result is not None
+        assert "description" in result
+        assert len(result["description"]) > 0
+
+
+# ------------------------------------------------------------------
+# Capability #67: get_examples and next_token_suggestions
+# ------------------------------------------------------------------
+
+
+class TestGetExamples:
+    """Tests for the get_examples capability (#67)."""
+
+    def test_returns_list(self, provider: AgentAPIProvider):
+        result = provider.get_examples()
+        assert isinstance(result, list)
+        assert len(result) >= 3
+
+    def test_each_example_has_name_and_source(
+        self, provider: AgentAPIProvider
+    ):
+        for example in provider.get_examples():
+            assert "name" in example
+            assert "source" in example
+            assert len(example["source"]) > 0
+
+    def test_example_has_geometry(self, provider: AgentAPIProvider):
+        examples = provider.get_examples()
+        sources = " ".join(e["source"] for e in examples)
+        assert "geometry" in sources
+
+    def test_example_has_task(self, provider: AgentAPIProvider):
+        examples = provider.get_examples()
+        sources = " ".join(e["source"] for e in examples)
+        assert "task" in sources
+
+    def test_returns_copy(self, provider: AgentAPIProvider):
+        e1 = provider.get_examples()
+        e2 = provider.get_examples()
+        assert len(e1) == len(e2)
+        assert e1 is not e2
+
+
+class TestNextTokenSuggestions:
+    """Tests for the next_token_suggestions capability (#67)."""
+
+    def test_top_level_suggestions(self, provider: AgentAPIProvider):
+        suggestions = provider.next_token_suggestions("top_level")
+        assert len(suggestions) > 0
+        texts = [s["text"] for s in suggestions]
+        assert "geometry" in texts
+        assert "basis" in texts
+        assert "task" in texts
+
+    def test_task_theory_suggestions(self, provider: AgentAPIProvider):
+        suggestions = provider.next_token_suggestions("task_theory")
+        assert len(suggestions) > 0
+        texts = [s["text"] for s in suggestions]
+        assert "scf" in texts
+        assert "dft" in texts
+
+    def test_task_operation_suggestions(self, provider: AgentAPIProvider):
+        suggestions = provider.next_token_suggestions("task_operation")
+        assert len(suggestions) > 0
+        texts = [s["text"] for s in suggestions]
+        assert "energy" in texts
+        assert "optimize" in texts
+
+    def test_basis_set_suggestions(self, provider: AgentAPIProvider):
+        suggestions = provider.next_token_suggestions("basis_set")
+        assert len(suggestions) > 0
+        texts = [s["text"] for s in suggestions]
+        assert any("6-31" in t for t in texts)
+
+    def test_dft_functional_suggestions(self, provider: AgentAPIProvider):
+        suggestions = provider.next_token_suggestions("dft_functional")
+        assert len(suggestions) > 0
+        texts = [s["text"] for s in suggestions]
+        assert "B3LYP" in texts
+
+    def test_prefix_filter(self, provider: AgentAPIProvider):
+        suggestions = provider.next_token_suggestions("task_theory", "df")
+        texts = [s["text"] for s in suggestions]
+        assert all(t.lower().startswith("df") for t in texts)
+
+    def test_section_keyword_suggestions(self, provider: AgentAPIProvider):
+        suggestions = provider.next_token_suggestions("scf")
+        assert len(suggestions) > 0
+        texts = [s["text"] for s in suggestions]
+        assert "maxiter" in texts
+
+    def test_unknown_context_returns_empty_or_section(
+        self, provider: AgentAPIProvider
+    ):
+        suggestions = provider.next_token_suggestions("unknown_context_xyz")
+        # Should return empty list (no matching section)
+        assert isinstance(suggestions, list)
+
+
+# ------------------------------------------------------------------
+# Capability #74: parse_log and parse_nwchem_output
+# ------------------------------------------------------------------
+
+
+class TestParseLog:
+    """Tests for the parse_log capability (#74)."""
+
+    def test_scf_convergence_failure(self, provider: AgentAPIProvider):
+        log_text = (
+            " ======================\n"
+            " SCF failed to converge after 100 iterations\n"
+            " ======================\n"
+        )
+        findings = provider.parse_log(log_text)
+        assert len(findings) >= 1
+        errors = [f for f in findings if f["code"] == "NWCHEM-E044"]
+        assert len(errors) >= 1
+        assert any("converge" in f["message"] for f in errors)
+
+    def test_fatal_error(self, provider: AgentAPIProvider):
+        log_text = "FATAL ERROR: unable to allocate memory\n"
+        findings = provider.parse_log(log_text)
+        assert len(findings) >= 1
+        errors = [f for f in findings if f["code"] == "NWCHEM-E044"]
+        assert len(errors) >= 1
+
+    def test_insufficient_memory(self, provider: AgentAPIProvider):
+        log_text = "Insufficient memory for calculation\n"
+        findings = provider.parse_log(log_text)
+        assert len(findings) >= 1
+        assert any("memory" in f["message"].lower() for f in findings)
+
+    def test_scf_energy_extract(self, provider: AgentAPIProvider):
+        log_text = "Total SCF energy = -76.02345678\n"
+        findings = provider.parse_log(log_text)
+        assert len(findings) >= 1
+        info = [f for f in findings if f["code"] == "NWCHEM-INFO-001"]
+        assert len(info) >= 1
+        assert info[0].get("value") == "-76.02345678"
+
+    def test_dft_energy_extract(self, provider: AgentAPIProvider):
+        log_text = "Total DFT energy = -76.45678901\n"
+        findings = provider.parse_log(log_text)
+        dft_info = [f for f in findings if f["code"] == "NWCHEM-INFO-002"]
+        assert len(dft_info) >= 1
+
+    def test_optimization_converged(self, provider: AgentAPIProvider):
+        log_text = "Optimization converged.  Stationary point found.\n"
+        findings = provider.parse_log(log_text)
+        opt_info = [f for f in findings if f["code"] == "NWCHEM-INFO-003"]
+        assert len(opt_info) >= 1
+
+    def test_clean_log_no_errors(self, provider: AgentAPIProvider):
+        log_text = (
+            " ======================\n"
+            " NWChem input processed successfully\n"
+            " Normal termination\n"
+        )
+        findings = provider.parse_log(log_text)
+        errors = [f for f in findings if f["severity"] == "error"]
+        assert len(errors) == 0
+
+    def test_basis_not_found(self, provider: AgentAPIProvider):
+        log_text = "could not find basis set FAKE-BASIS on the library\n"
+        findings = provider.parse_log(log_text)
+        errors = [f for f in findings if f["code"] == "NWCHEM-E044"]
+        assert len(errors) >= 1
+
+    def test_empty_log(self, provider: AgentAPIProvider):
+        findings = provider.parse_log("")
+        assert findings == []
+
+
+class TestParseNwchemOutput:
+    """Tests for the parse_nwchem_output capability (#74)."""
+
+    def test_file_not_found(self, provider: AgentAPIProvider):
+        with pytest.raises(FileNotFoundError):
+            provider.parse_nwchem_output("/nonexistent/path/output.out")
+
+    def test_parse_output_file(self, provider: AgentAPIProvider):
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".out", delete=False
+        ) as f:
+            f.write("SCF failed to converge after 200 iterations\n")
+            f.write("Total SCF energy = -76.05\n")
+            f.flush()
+            findings = provider.parse_nwchem_output(f.name)
+            assert len(findings) >= 2
+            errors = [f for f in findings if f["severity"] == "error"]
+            assert len(errors) >= 1
+
+
+# ------------------------------------------------------------------
+# Capability #84: get_rule_manifest and openqc_smoke
+# ------------------------------------------------------------------
+
+
+class TestGetRuleManifest:
+    """Tests for the get_rule_manifest capability (#84)."""
+
+    def test_returns_dict(self, provider: AgentAPIProvider):
+        manifest = provider.get_rule_manifest()
+        assert isinstance(manifest, dict)
+
+    def test_has_provider(self, provider: AgentAPIProvider):
+        manifest = provider.get_rule_manifest()
+        assert manifest["provider"] == "nwchem-lsp"
+
+    def test_has_rules(self, provider: AgentAPIProvider):
+        manifest = provider.get_rule_manifest()
+        assert "rules" in manifest
+        assert len(manifest["rules"]) > 0
+
+    def test_has_categories(self, provider: AgentAPIProvider):
+        manifest = provider.get_rule_manifest()
+        assert "categories" in manifest
+        assert "syntax" in manifest["categories"]
+        assert "schema" in manifest["categories"]
+        assert "best_practice" in manifest["categories"]
+        assert "issue_mapped" in manifest["categories"]
+
+    def test_has_rule_count(self, provider: AgentAPIProvider):
+        manifest = provider.get_rule_manifest()
+        assert "rule_count" in manifest
+        assert manifest["rule_count"] > 0
+
+    def test_issue_mapped_codes_in_manifest(self, provider: AgentAPIProvider):
+        manifest = provider.get_rule_manifest()
+        issue_mapped = manifest["categories"]["issue_mapped"]
+        expected = [
+            "NWCHEM-E040", "NWCHEM-W040", "NWCHEM-E041", "NWCHEM-E042",
+            "NWCHEM-W041", "NWCHEM-W042", "NWCHEM-W043", "NWCHEM-E043",
+            "NWCHEM-E044",
+        ]
+        for code in expected:
+            assert code in issue_mapped, f"Missing {code} in issue_mapped"
+
+    def test_capabilities_fixture_exists(self):
+        """Golden capabilities fixture should be present."""
+        fixture_path = CAPABILITIES_FIXTURES_DIR / "nwchem_capabilities.json"
+        assert fixture_path.exists(), "Capabilities fixture not found"
+
+    def test_capabilities_fixture_valid(self):
+        """Golden capabilities fixture should be valid JSON."""
+        fixture_path = CAPABILITIES_FIXTURES_DIR / "nwchem_capabilities.json"
+        with open(fixture_path) as f:
+            data = json.load(f)
+        assert "capabilities" in data
+        assert len(data["capabilities"]) >= 5
+
+
+class TestOpenqcSmoke:
+    """Tests for the openqc_smoke capability (#84)."""
+
+    def test_returns_dict(self, provider: AgentAPIProvider):
+        result = provider.openqc_smoke()
+        assert isinstance(result, dict)
+
+    def test_all_checks_pass(self, provider: AgentAPIProvider):
+        result = provider.openqc_smoke()
+        assert result["status"] == "pass", (
+            f"Smoke test failed: {result}"
+        )
+
+    def test_has_checks(self, provider: AgentAPIProvider):
+        result = provider.openqc_smoke()
+        assert "checks" in result
+        assert len(result["checks"]) >= 8
+
+    def test_has_check_count(self, provider: AgentAPIProvider):
+        result = provider.openqc_smoke()
+        assert result["check_count"] >= 8
+        assert result["passed"] >= 8
+        assert result["failed"] == 0
+
+    def test_lint_provider_check(self, provider: AgentAPIProvider):
+        result = provider.openqc_smoke()
+        lint_check = next(
+            c for c in result["checks"] if c["name"] == "lint_provider"
+        )
+        assert lint_check["status"] == "pass"
+
+    def test_describe_domain_language_check(
+        self, provider: AgentAPIProvider
+    ):
+        result = provider.openqc_smoke()
+        check = next(
+            c
+            for c in result["checks"]
+            if c["name"] == "describe_domain_language"
+        )
+        assert check["status"] == "pass"
+
+    def test_lookup_section_check(self, provider: AgentAPIProvider):
+        result = provider.openqc_smoke()
+        check = next(
+            c for c in result["checks"] if c["name"] == "lookup_section"
+        )
+        assert check["status"] == "pass"
+
+    def test_lookup_keyword_check(self, provider: AgentAPIProvider):
+        result = provider.openqc_smoke()
+        check = next(
+            c for c in result["checks"] if c["name"] == "lookup_keyword"
+        )
+        assert check["status"] == "pass"
+
+    def test_examples_check(self, provider: AgentAPIProvider):
+        result = provider.openqc_smoke()
+        check = next(
+            c for c in result["checks"] if c["name"] == "get_examples"
+        )
+        assert check["status"] == "pass"
+
+    def test_suggestions_check(self, provider: AgentAPIProvider):
+        result = provider.openqc_smoke()
+        check = next(
+            c
+            for c in result["checks"]
+            if c["name"] == "next_token_suggestions"
+        )
+        assert check["status"] == "pass"
+
+    def test_parse_log_check(self, provider: AgentAPIProvider):
+        result = provider.openqc_smoke()
+        check = next(
+            c for c in result["checks"] if c["name"] == "parse_log"
+        )
+        assert check["status"] == "pass"
+
+    def test_rule_manifest_check(self, provider: AgentAPIProvider):
+        result = provider.openqc_smoke()
+        check = next(
+            c for c in result["checks"] if c["name"] == "get_rule_manifest"
+        )
+        assert check["status"] == "pass"

--- a/tests/features/test_lint.py
+++ b/tests/features/test_lint.py
@@ -1,15 +1,21 @@
 """Tests for the schema-aware lint provider."""
 
+import json
 import pathlib
 
 import pytest
 
 from lsprotocol.types import Diagnostic, DiagnosticSeverity
 
-from nwchem_lsp.features.lint import NwchemLintProvider, RULE_DESCRIPTIONS
+from nwchem_lsp.features.lint import (
+    NwchemLintProvider,
+    RULE_DESCRIPTIONS,
+    _NW_TO_NWCHEM_MAP,
+)
 
 
 FIXTURES_DIR = pathlib.Path(__file__).parent.parent / "lint"
+RULES_FIXTURES_DIR = pathlib.Path(__file__).parent.parent / "fixtures" / "rules"
 
 
 @pytest.fixture
@@ -47,7 +53,9 @@ class TestRuleRegistry:
         """Every rule code should have a description."""
         assert len(RULE_DESCRIPTIONS) > 0
         for code, desc in RULE_DESCRIPTIONS.items():
-            assert code.startswith("NW"), f"Rule code {code} does not start with NW"
+            assert code.startswith("NW") or code.startswith("NWCHEM-"), (
+                f"Rule code {code} does not start with NW or NWCHEM-"
+            )
             assert len(desc) > 0, f"Rule {code} has empty description"
 
     def test_syntax_rules_in_1000_range(self):
@@ -74,6 +82,41 @@ class TestRuleRegistry:
             num = int(rule[2:])
             assert 3000 <= num <= 3999
 
+    def test_nwchem_issue_mapped_codes_exist(self):
+        """NWCHEM-Exxxx / NWCHEM-Wxxxx issue-mapped codes should be present."""
+        issue_codes = {
+            c for c in RULE_DESCRIPTIONS if c.startswith("NWCHEM-")
+        }
+        expected = {
+            "NWCHEM-E040", "NWCHEM-W040", "NWCHEM-E041", "NWCHEM-E042",
+            "NWCHEM-W041", "NWCHEM-W042", "NWCHEM-W043", "NWCHEM-E043",
+            "NWCHEM-E044",
+        }
+        assert expected.issubset(issue_codes), (
+            f"Missing issue-mapped codes: {expected - issue_codes}"
+        )
+
+    def test_nw_to_nwchem_map_consistency(self):
+        """Each mapped NW code should exist in RULE_DESCRIPTIONS."""
+        for nw_code, nwchem_code in _NW_TO_NWCHEM_MAP.items():
+            assert nw_code in RULE_DESCRIPTIONS, (
+                f"Mapped NW code {nw_code} not in RULE_DESCRIPTIONS"
+            )
+            assert nwchem_code in RULE_DESCRIPTIONS, (
+                f"Mapped NWCHEM code {nwchem_code} not in RULE_DESCRIPTIONS"
+            )
+
+    def test_rules_fixture_matches_registry(self):
+        """Golden fixture should match the RULE_DESCRIPTIONS keys."""
+        fixture_path = RULES_FIXTURES_DIR / "nwchem_rules.json"
+        if fixture_path.exists():
+            with open(fixture_path) as f:
+                fixture_rules = json.load(f)["rules"]
+            for code in fixture_rules:
+                assert code in RULE_DESCRIPTIONS, (
+                    f"Fixture code {code} not in RULE_DESCRIPTIONS"
+                )
+
 
 # ------------------------------------------------------------------
 # Provider basics
@@ -94,8 +137,18 @@ class TestLintProvider:
 
     def test_lint_returns_diagnostics(self, provider):
         """Test that lint returns Diagnostic objects."""
-        result = provider.lint("geometry\n  H 0 0 0\nend\nbasis\n  H library 6-31g\nend\ntask scf energy\n")
+        result = provider.lint(
+            "geometry\n  H 0 0 0\nend\nbasis\n  H library 6-31g\nend\n"
+            "task scf energy\n"
+        )
         assert all(isinstance(d, Diagnostic) for d in result)
+
+    def test_check_alias(self, provider):
+        """check() should be an alias for lint()."""
+        text = "geometry\n  H 0 0 0\nend\nbasis\n  * library 6-31g\nend\ntask scf energy\n"
+        lint_result = provider.lint(text)
+        check_result = provider.check(text)
+        assert len(lint_result) == len(check_result)
 
 
 # ------------------------------------------------------------------
@@ -211,6 +264,119 @@ class TestSchemaChecks:
 
 
 # ------------------------------------------------------------------
+# New issue-mapped rules (#75-#83)
+# ------------------------------------------------------------------
+
+
+class TestIssueMappedRules:
+    """Tests for NWCHEM-Exxxx / NWCHEM-Wxxxx issue-mapped rule codes."""
+
+    def test_unknown_directive_emits_nwchem_e040(self, provider):
+        """NWCHEM-E040: Unknown section/directive emits dual code."""
+        diags = lint_fixture("unknown_directive.nw", provider)
+        assert "NWCHEM-E040" in codes(diags)
+        nwchem_diags = [d for d in diags if str(d.code) == "NWCHEM-E040"]
+        assert any("foobarbaz" in d.message for d in nwchem_diags)
+
+    def test_duplicate_section_emits_nwchem_w040(self, provider):
+        """NWCHEM-W040: Duplicate section emits dual code."""
+        diags = lint_fixture("duplicate_section.nw", provider)
+        assert "NWCHEM-W040" in codes(diags)
+
+    def test_unknown_task_operation_emits_nwchem_e041(self, provider):
+        """NWCHEM-E041: Task missing operation emits dual code."""
+        diags = lint_fixture("unknown_task_operation.nw", provider)
+        assert "NWCHEM-E041" in codes(diags)
+
+    def test_unknown_theory_emits_nwchem_e042(self, provider):
+        """NWCHEM-E042: Unknown task theory emits dual code."""
+        diags = lint_fixture("unknown_task_theory.nw", provider)
+        assert "NWCHEM-E042" in codes(diags)
+
+    def test_unknown_basis_emits_nwchem_w041(self, provider):
+        """NWCHEM-W041: Unknown basis set emits dual code."""
+        diags = lint_fixture("unknown_basis.nw", provider)
+        assert "NWCHEM-W041" in codes(diags)
+
+    def test_unknown_functional_emits_nwchem_w042(self, provider):
+        """NWCHEM-W042: Unknown DFT functional emits dual code."""
+        diags = lint_fixture("unknown_functional.nw", provider)
+        assert "NWCHEM-W042" in codes(diags)
+
+    def test_loose_convergence_emits_nwchem_w043(self, provider):
+        """NWCHEM-W043: Loose convergence threshold emits dual code."""
+        diags = lint_fixture("loose_convergence.nw", provider)
+        assert "NWCHEM-W043" in codes(diags)
+
+
+# ------------------------------------------------------------------
+# Geometry malformed (#82 -> NW2012 / NWCHEM-E043)
+# ------------------------------------------------------------------
+
+
+class TestGeometryMalformed:
+    """Tests for NW2012: Geometry section malformed atom coordinates."""
+
+    def test_geometry_missing_coords(self, provider):
+        """NW2012: Atom line with fewer than 3 coordinates."""
+        diags = lint_fixture("geometry_malformed.nw", provider)
+        assert "NW2012" in codes(diags)
+        malform_diags = [d for d in diags if str(d.code) == "NW2012"]
+        assert len(malform_diags) >= 1
+        # Should flag O (only 2 coords) or H (non-numeric)
+        messages = " ".join(d.message for d in malform_diags)
+        assert "fewer than 3 coordinates" in messages or "Non-numeric" in messages
+
+    def test_geometry_non_numeric_coords(self, provider):
+        """NW2012: Atom line with non-numeric coordinate values."""
+        diags = lint_fixture("geometry_malformed.nw", provider)
+        malform_diags = [d for d in diags if str(d.code) == "NW2012"]
+        messages = " ".join(d.message for d in malform_diags)
+        assert "Non-numeric" in messages or "abc" in messages
+
+    def test_geometry_malformed_emits_nwchem_e043(self, provider):
+        """NWCHEM-E043: Geometry malformed emits dual code."""
+        diags = lint_fixture("geometry_malformed.nw", provider)
+        assert "NWCHEM-E043" in codes(diags)
+
+    def test_valid_geometry_no_malformed(self, provider):
+        """Valid geometry should not produce NW2012."""
+        diags = lint_fixture("valid_input.nw", provider)
+        assert "NW2012" not in codes(diags)
+
+
+# ------------------------------------------------------------------
+# Task missing operation (#77 -> NWCHEM-E041)
+# ------------------------------------------------------------------
+
+
+class TestTaskMissingOperation:
+    """Tests for NWCHEM-E041: Task directive missing operation."""
+
+    def test_task_missing_operation(self, provider):
+        """Task with only theory and no operation should be flagged."""
+        diags = lint_fixture("task_missing_operation.nw", provider)
+        assert "NWCHEM-E041" in codes(diags)
+        missing_op = [d for d in diags if str(d.code) == "NWCHEM-E041"]
+        assert any("dft" in d.message for d in missing_op)
+
+    def test_task_with_operation_not_flagged(self, provider):
+        """Task with both theory and operation should not be flagged."""
+        diags = lint_fixture("valid_input.nw", provider)
+        assert "NWCHEM-E041" not in codes(diags)
+
+    def test_inline_task_missing_operation(self, provider):
+        """Inline test: task with no operation."""
+        text = (
+            "geometry\n  H 0 0 0\nend\n"
+            "basis\n  * library 6-31g\nend\n"
+            "task scf\n"
+        )
+        diags = provider.lint(text)
+        assert "NWCHEM-E041" in codes(diags)
+
+
+# ------------------------------------------------------------------
 # Best-practice checks (NW3xxx)
 # ------------------------------------------------------------------
 
@@ -262,6 +428,12 @@ class TestNoFalsePositives:
         diags = lint_fixture("valid_input.nw", provider)
         syntax_codes = {c for c in codes(diags) if c.startswith("NW1")}
         assert len(syntax_codes) == 0
+
+    def test_valid_input_no_nwchem_error_codes(self, provider):
+        """Valid fixture should not produce NWCHEM-E codes."""
+        diags = lint_fixture("valid_input.nw", provider)
+        error_codes = {c for c in codes(diags) if "NWCHEM-E" in c}
+        assert len(error_codes) == 0
 
 
 # ------------------------------------------------------------------
@@ -322,6 +494,9 @@ class TestLintFixtures:
         "invalid_grid.nw",
         "invalid_units.nw",
         "missing_required.nw",
+        "geometry_malformed.nw",
+        "task_missing_operation.nw",
+        "loose_convergence.nw",
     ]
 
     @pytest.mark.parametrize("fixture_name", FIXTURE_NAMES)

--- a/tests/fixtures/capabilities/nwchem_capabilities.json
+++ b/tests/fixtures/capabilities/nwchem_capabilities.json
@@ -1,0 +1,58 @@
+{
+  "capabilities": [
+    {
+      "id": "describe_domain_language",
+      "issue": 65,
+      "description": "NWChem input language description",
+      "returns": "Dict[str, Any] with sections, keywords, task_directives"
+    },
+    {
+      "id": "lookup_section",
+      "issue": 66,
+      "description": "Schema lookup for section metadata",
+      "signature": "lookup_section(name: str) -> Optional[Dict[str, Any]]"
+    },
+    {
+      "id": "lookup_keyword",
+      "issue": 66,
+      "description": "Schema lookup for keyword within section",
+      "signature": "lookup_keyword(section: str, keyword: str) -> Optional[Dict[str, Any]]"
+    },
+    {
+      "id": "get_examples",
+      "issue": 67,
+      "description": "Curated NWChem input examples",
+      "returns": "List[Dict[str, str]] with name and source"
+    },
+    {
+      "id": "next_token_suggestions",
+      "issue": 67,
+      "description": "Context-aware token suggestions",
+      "signature": "next_token_suggestions(context: str, prefix: str) -> List[Dict[str, str]]"
+    },
+    {
+      "id": "parse_log",
+      "issue": 74,
+      "description": "Parse NWChem log output for errors and info",
+      "signature": "parse_log(text: str) -> List[Dict[str, Any]]"
+    },
+    {
+      "id": "parse_nwchem_output",
+      "issue": 74,
+      "description": "Parse NWChem output file from path",
+      "signature": "parse_nwchem_output(path: str) -> List[Dict[str, Any]]"
+    },
+    {
+      "id": "get_rule_manifest",
+      "issue": 84,
+      "description": "Full rule code catalog",
+      "returns": "Dict[str, Any] with rules and categories"
+    },
+    {
+      "id": "openqc_smoke",
+      "issue": 84,
+      "description": "Lightweight smoke test for OpenQC integration",
+      "returns": "Dict[str, Any] with status and checks"
+    }
+  ]
+}

--- a/tests/fixtures/rules/nwchem_rules.json
+++ b/tests/fixtures/rules/nwchem_rules.json
@@ -1,0 +1,97 @@
+{
+  "provider": "nwchem-lsp",
+  "rules": {
+    "NW1001": {
+      "severity": "error",
+      "description": "Unclosed section"
+    },
+    "NW1002": {
+      "severity": "error",
+      "description": "Unexpected 'end' without matching section"
+    },
+    "NW2001": {
+      "severity": "warning",
+      "description": "Unknown keyword inside section"
+    },
+    "NW2004": {
+      "severity": "error",
+      "description": "Missing required section"
+    },
+    "NW2005": {
+      "severity": "error",
+      "description": "Unknown task theory"
+    },
+    "NW2006": {
+      "severity": "warning",
+      "description": "Unknown task operation"
+    },
+    "NW2007": {
+      "severity": "warning",
+      "description": "Unknown basis set name"
+    },
+    "NW2008": {
+      "severity": "warning",
+      "description": "Unknown DFT functional"
+    },
+    "NW2009": {
+      "severity": "warning",
+      "description": "Unknown top-level directive"
+    },
+    "NW2010": {
+      "severity": "warning",
+      "description": "Duplicate section (only one allowed)"
+    },
+    "NW2012": {
+      "severity": "error",
+      "description": "Geometry section has malformed atom coordinates"
+    },
+    "NW3001": {
+      "severity": "hint",
+      "description": "SCF maxiter outside typical range (1-500)"
+    },
+    "NW3002": {
+      "severity": "hint",
+      "description": "Convergence threshold unusually loose"
+    },
+    "NW3003": {
+      "severity": "information",
+      "description": "Duplicate task directive"
+    },
+    "NWCHEM-E040": {
+      "severity": "warning",
+      "description": "Unknown section or directive name"
+    },
+    "NWCHEM-W040": {
+      "severity": "warning",
+      "description": "Same section declared twice"
+    },
+    "NWCHEM-E041": {
+      "severity": "warning",
+      "description": "Task directive missing operation (energy/optimize/etc)"
+    },
+    "NWCHEM-E042": {
+      "severity": "error",
+      "description": "Task theory not in known set"
+    },
+    "NWCHEM-W041": {
+      "severity": "warning",
+      "description": "Basis set not recognized"
+    },
+    "NWCHEM-W042": {
+      "severity": "warning",
+      "description": "DFT functional not recognized"
+    },
+    "NWCHEM-W043": {
+      "severity": "hint",
+      "description": "Loose SCF convergence threshold"
+    },
+    "NWCHEM-E043": {
+      "severity": "error",
+      "description": "Geometry section has errors"
+    },
+    "NWCHEM-E044": {
+      "severity": "error",
+      "description": "Runtime parse error from NWChem log output"
+    }
+  }
+}

--- a/tests/lint/geometry_malformed.nw
+++ b/tests/lint/geometry_malformed.nw
@@ -1,0 +1,12 @@
+# Geometry section with malformed atom coordinates
+geometry
+  O  0.0  0.0
+  H  abc  0.8  0.6
+  C  1.0  2.0  3.0
+end
+
+basis
+  * library 6-31g*
+end
+
+task scf energy

--- a/tests/lint/task_missing_operation.nw
+++ b/tests/lint/task_missing_operation.nw
@@ -1,0 +1,10 @@
+# Task with missing operation
+geometry
+  H 0 0 0
+end
+
+basis
+  * library 6-31G*
+end
+
+task dft

--- a/wiki/concepts/Basis_Set_Selection.md
+++ b/wiki/concepts/Basis_Set_Selection.md
@@ -1,0 +1,99 @@
+# Basis Set Selection (基组选择策略)
+
+> 类型：概念
+> 学科/领域：量子化学
+
+## 定义 (Definition)
+
+基组选择是平衡计算精度和成本的关键决策。基组质量直接影响计算结果的准确性。
+
+## 基组分类 (Basis Set Classification)
+
+### 最小基组 (Minimal Basis)
+- `STO-3G`
+- 每个原子一个基函数
+- 用途：快速测试、教学演示
+
+### 分裂价键基组 (Split-Valence)
+- `3-21G`, `6-31G`, `6-311G`
+- 价轨道分裂为多个基函数
+- 用途：常规计算
+
+### 极化基组 (Polarized Basis)
+- `6-31G*` / `6-31G(d)` - 添加 d 极化函数
+- `6-31G**` / `6-31G(d,p)` - 重原子加 d，氢加 p
+- 用途：精确几何、能量
+
+### 弥散函数基组 (Diffuse Basis)
+- `6-31+G*` - 添加弥散函数
+- `aug-cc-pVXZ` - 全部元素加弥散
+- 用途：阴离子、弱相互作用、激发态
+
+### 相关一致基组 (Correlation-Consistent)
+- `cc-pVDZ`, `cc-pVTZ`, `cc-pVQZ`, `cc-pV5Z`
+- 系统收敛，适合外推
+- 用途：高精度相关能计算
+
+## 选择策略 (Selection Strategy)
+
+### DFT 计算
+```nwchem
+# 标准计算
+basis spherical
+  * library 6-31G*
+end
+
+# 高精度
+basis spherical
+  * library def2-TZVP
+end
+
+# 弱相互作用/阴离子
+basis spherical
+  * library aug-cc-pVTZ
+end
+```
+
+### 高精度波函数方法
+```nwchem
+# MP2/CCSD
+basis spherical
+  * library cc-pVTZ
+end
+
+# 完全基组极限外推
+basis spherical
+  * library cc-pVQZ
+end
+```
+
+### 过渡金属
+```nwchem
+# 赝势 + 双-zeta
+ecp
+  * library LANL2DZ
+end
+
+basis spherical
+  * library LANL2DZ
+end
+```
+
+## 基组与方法的匹配 (Basis-Method Matching)
+
+| 方法 | 推荐基组 | 说明 |
+|------|---------|------|
+| DFT-GGA | 6-31G*, def2-SVP | 标准精度 |
+| DFT-杂化 | def2-TZVP, cc-pVTZ | 高精度 |
+| MP2 | cc-pVTZ, aug-cc-pVDZ | 需要极化 |
+| CCSD(T) | cc-pVTZ/cc-pVQZ | 接近完全基组极限 |
+
+## 相关概念 (Related Concepts)
+
+- [[Basis_Set]]
+- [[ECP]]
+- [[MP2]]
+
+## 来源 (Sources)
+
+- `raw/assets/keywords_data.py` - BASIS_SETS

--- a/wiki/concepts/Convergence_Control.md
+++ b/wiki/concepts/Convergence_Control.md
@@ -1,0 +1,88 @@
+# Convergence Control (收敛控制)
+
+> 类型：概念
+> 学科/领域：量子化学计算
+
+## 定义 (Definition)
+
+收敛控制参数决定 SCF 和几何优化的精度和收敛行为。
+
+## SCF 收敛 (SCF Convergence)
+
+### 收敛阈值 (Convergence Threshold)
+```nwchem
+scf
+  thresh 1e-8
+end
+
+# DFT 中的收敛控制
+dft
+  convergence energy 1e-8
+  convergence density 1e-6
+  convergence gradient 1e-5
+end
+```
+
+### 最大迭代次数 (Maximum Iterations)
+```nwchem
+scf
+  maxiter 200
+end
+
+dft
+  iterations 150
+end
+```
+
+### 收敛加速 (Convergence Acceleration)
+```nwchem
+scf
+  diis          # DIIS 加速（默认启用）
+  levelshifting  # 能级移动
+  damping        # 阻尼
+end
+```
+
+## 几何优化收敛 (Geometry Optimization Convergence)
+
+NWChem 默认使用内部优化器，收敛标准包括：
+- 能量变化
+- 梯度最大分量
+- 梯度均方根
+- 位移变化
+
+## 常见收敛问题 (Common Convergence Problems)
+
+### SCF 不收敛
+- 症状：达到最大迭代次数仍未收敛
+- 解决方案：
+  1. 降低收敛阈值（`thresh 1e-5`）
+  2. 增加最大迭代次数（`maxiter 200`）
+  3. 尝试更好的初始猜测（`scf guess`）
+  4. 使用阻尼或能级移动
+
+### 几何优化不收敛
+- 症状：优化步数过多
+- 解决方案：
+  1. 改变优化算法
+  2. 检查势能面的平坦区域
+  3. 尝试更好的初始几何
+
+## 收敛阈值推荐 (Recommended Thresholds)
+
+| 计算类型 | SCF 阈值 | 几何优化阈值 |
+|---------|---------|-------------|
+| 快速测试 | 1e-5 | 宽松 |
+| 标准计算 | 1e-6 | 标准 |
+| 高精度 | 1e-8 | 严格 |
+| 发表级 | 1e-10 | 极严格 |
+
+## 相关概念 (Related Concepts)
+
+- [[SCF]]
+- [[DFT]]
+- [[Task_Operation]]
+
+## 来源 (Sources)
+
+- `raw/assets/keywords_data.py` - SCF_KEYWORDS, DFT_KEYWORDS

--- a/wiki/concepts/Geometry_Input_Formats.md
+++ b/wiki/concepts/Geometry_Input_Formats.md
@@ -1,0 +1,98 @@
+# Geometry Input Formats (几何输入格式)
+
+> 类型：概念
+> 学科/领域：量子化学输入
+
+## 定义 (Definition)
+
+NWChem 支持多种几何输入格式，包括笛卡尔坐标、Z 矩阵等。
+
+## 笛卡尔坐标格式 (Cartesian Coordinates)
+
+最常用的格式，直接指定 x, y, z 坐标：
+
+```nwchem
+geometry units angstroms
+  O  0.000  0.000  0.000
+  H  0.000  0.790  0.580
+  H  0.000 -0.790  0.580
+end
+```
+
+格式：`<元素> <x> <y> <z>`
+
+## 单位选项 (Unit Options)
+
+- `angstroms` - 埃（默认常用）
+- `bohr` / `au` - 原子单位
+- `nanometers` - 纳米
+- `picometers` - 皮米
+
+## Z 矩阵格式 (Z-Matrix)
+
+内坐标格式，用键长、键角、二面角定义：
+
+```nwchem
+geometry noautoz
+  O
+  H  1  0.96
+  H  1  0.96  2  104.5
+end
+```
+
+格式：`<元素> [参考原子1] [键长] [参考原子2] [键角] [参考原子3] [二面角]`
+
+## 几何优化选项 (Geometry Optimization Options)
+
+### 对称性 (Symmetry)
+- `autosym` - 自动检测分子对称性
+- `noautosym` - 禁用对称性检测
+
+### 坐标系统 (Coordinate Systems)
+- `center` - 将分子中心置于原点
+- `nocenter` - 不移动分子
+
+### 周期性系统 (Periodic Systems)
+- `system crystal` - 晶体
+- `system slab` - 表面/平板
+- `system polymer` - 聚合物
+- `system helix` - 螺旋结构
+
+## 示例 (Examples)
+
+### 水分子（笛卡尔）
+```nwchem
+geometry units angstroms
+  O  0.000  0.000  0.000
+  H  0.000  0.790  0.580
+  H  0.000 -0.790  0.580
+end
+```
+
+### 苯（自动对称）
+```nwchem
+geometry units angstroms autosym
+  C    1.398    0.000    0.000
+  C    0.699    1.212    0.000
+  C   -0.699    1.212    0.000
+  C   -1.398    0.000    0.000
+  C   -0.699   -1.212    0.000
+  C    0.699   -1.212    0.000
+  H    2.482    0.000    0.000
+  H    1.241    2.152    0.000
+  H   -1.241    2.152    0.000
+  H   -2.482    0.000    0.000
+  H   -1.241   -2.152    0.000
+  H    1.241   -2.152    0.000
+end
+```
+
+## 相关概念 (Related Concepts)
+
+- [[Geometry_Section]]
+- [[Chemical_Elements]]
+
+## 来源 (Sources)
+
+- `raw/assets/keywords_data.py` - GEOMETRY_KEYWORDS
+- `raw/assets/water_dft.nw`

--- a/wiki/concepts/Quantum_Chemistry_Methods.md
+++ b/wiki/concepts/Quantum_Chemistry_Methods.md
@@ -1,0 +1,67 @@
+# Quantum Chemistry Methods (量子化学方法层级)
+
+> 类型：概念
+> 学科/领域：量子化学
+
+## 定义 (Definition)
+
+量子化学方法按精度和计算成本分为多个层级，从快速的经验方法到高精度的从头算方法。
+
+## 方法层级 (Method Hierarchy)
+
+### 1. 经验方法 (Empirical Methods)
+- 计算成本：最低
+- 精度：定性
+- 适用场景：快速筛选、超大规模
+
+### 2. 半经验方法 (Semi-Empirical)
+- 计算成本：O(N³)
+- 精度：中等
+- 方法：AM1, PM3, MNDO
+- 适用场景：中等有机分子
+
+### 3. Hartree-Fock (HF)
+- 计算成本：O(N⁴)
+- 精度：定性，无电子相关
+- NWChem: `task scf`
+- 局限：不包含电子相关能量
+
+### 4. 密度泛函理论 (DFT)
+- 计算成本：O(N³) 到 O(N⁴)
+- 精度：定量
+- NWChem: `task dft`
+- 常用泛函：B3LYP, PBE0, wB97X-D
+- 适用场景：最常用的方法
+
+### 5. 微扰理论 (MP2, MP3, MP4)
+- 计算成本：MP2 O(N⁵), MP3 O(N⁶), MP4 O(N⁷)
+- 精度：良好
+- NWChem: `task mp2`
+- 适用场景：中等大小分子的相关能校正
+
+### 6. 耦合簇方法 (CCSD, CCSD(T))
+- 计算成本：CCSD O(N⁶), CCSD(T) O(N⁷)
+- 精度：极高（金标准）
+- NWChem: `task ccsd(t)`
+- 局限：仅适用于小分子
+
+## 方法选择指南 (Method Selection Guide)
+
+| 分子大小 | 推荐方法 | 精度/成本平衡 |
+|---------|---------|--------------|
+| > 200 原子 | 半经验 | 快速筛选 |
+| 50-200 原子 | DFT (GGA) | 日常计算 |
+| 20-50 原子 | DFT (杂化) | 精确计算 |
+| 10-20 原子 | DFT + 色散 | 高精度 |
+| < 10 原子 | CCSD(T) | 金标准 |
+
+## 相关概念 (Related Concepts)
+
+- [[DFT]]
+- [[MP2]]
+- [[CCSD]]
+
+## 来源 (Sources)
+
+- `raw/assets/README.md`
+- 量子化学标准教材

--- a/wiki/concepts/Spin_and_Multiplicity.md
+++ b/wiki/concepts/Spin_and_Multiplicity.md
@@ -1,0 +1,98 @@
+# Spin and Multiplicity (自旋与多重度)
+
+> 类型：概念
+> 学科/领域：量子化学
+
+## 定义 (Definition)
+
+自旋态和多重度是描述分子电子状态的基本参数，影响 SCF 方法的类型选择。
+
+## 多重度定义 (Multiplicity Definition)
+
+多重度 = 2S + 1，其中 S 是总自旋量子数。
+
+## 常见自旋态 (Common Spin States)
+
+### 单重态 (Singlet, Mult = 1)
+- 所有电子配对
+- 闭壳层分子
+- 示例：H₂, CO, 苯
+
+```nwchem
+scf
+  singlet
+  rhf
+end
+```
+
+### 二重态 (Doublet, Mult = 2)
+- 一个未配对电子
+- 自由基
+- 示例：CH₃•, OH•
+
+```nwchem
+scf
+  doublet
+  uhf
+end
+
+# 或在 DFT 中
+dft
+  mult 2
+  odft
+end
+```
+
+### 三重态 (Triplet, Mult = 3)
+- 两个未配对电子
+- 示例：O₂（基态）
+
+```nwchem
+scf
+  triplet
+  uhf
+end
+```
+
+## SCF 方法与自旋 (SCF Methods and Spin)
+
+### 闭壳层 (Closed Shell)
+- `rhf` - 限制性 Hartree-Fock
+- 适用于：单重态
+
+### 开壳层 (Open Shell)
+- `uhf` - 非限制性 Hartree-Fock
+- 适用于：自由基、三重态等
+
+- `rohf` - 限制性开壳层 HF
+- 适用于：需要限制性形式的开壳层
+
+## 电荷与多重度 (Charge and Multiplicity)
+
+NWChem 通过 `charge` 命令设置总电荷：
+
+```nwchem
+charge -1  # 阴离子
+charge 0   # 中性分子
+charge +1  # 阳离子
+
+scf
+  doublet  # 对于阴离子自由基
+end
+```
+
+## 自旋污染 (Spin Contamination)
+
+UHF 计算可能产生自旋污染（⟨S²⟩ 偏离理论值）。
+- 检查：查看输出中的 ⟨S²⟩ 值
+- 解决：使用 ROHF 或更高精度方法
+
+## 相关概念 (Related Concepts)
+
+- [[SCF]]
+- [[DFT]]
+- [[Task_Operation]]
+
+## 来源 (Sources)
+
+- `raw/assets/keywords_data.py` - SCF_KEYWORDS

--- a/wiki/entities/Basis_Set.md
+++ b/wiki/entities/Basis_Set.md
@@ -1,0 +1,88 @@
+# Basis Set (基组)
+
+> 类型：量子化学概念
+> 创建日期：2026-06-12
+> 来源数：3
+
+## 简介 (Introduction)
+
+基组是用于描述分子轨道的数学函数集合。NWChem 支持多种标准基组库。
+
+## 语法结构 (Syntax Structure)
+
+```nwchem
+basis [spherical|cartesian]
+  <element> library <basis_name>
+  * library <basis_name>  # Apply to all elements
+end
+```
+
+## 常用基组 (Common Basis Sets)
+
+### Pople 系列 (Pople Series)
+- `STO-3G` - 最小基组 / Minimal basis
+- `3-21G` - 分裂价键基组
+- `6-31G` / `6-31G*` / `6-31G**` - 标准分裂价键
+- `6-311G` / `6-311G**` - 三重分裂价键
+- `6-31+G*` - 含弥散函数
+
+### Dunning 相关一致基组 (Dunning Correlation-Consistent)
+- `cc-pVDZ` - 相关一致双-zeta
+- `cc-pVTZ` - 相关一致三-zeta
+- `cc-pVQZ` / `cc-pV5Z` / `cc-pV6Z` - 更高精度
+- `aug-cc-pVXZ` - 含弥散函数增强
+
+### Def2 系列
+- `def2-SVP` - 分裂价键加极化
+- `def2-TZVP` - 三-zeta 价键加极化
+- `def2-TZVPP` / `def2-QZVP` / `def2-QZVPP`
+
+### 赝势基组 (ECP Basis Sets)
+- `LANL2DZ` / `LANL2TZ` - Los Alamos 赝势基组
+- `SDD` - Stuttgart-Dresden 赝势
+
+### 其他
+- `DGDZVP` - Godunov 基组
+- `MINI` / `MIDI` - 小型基组
+
+## 示例 (Examples)
+
+```nwchem
+# Apply 6-31G* to all elements
+basis spherical
+  * library 6-31G*
+end
+
+# Different basis for different elements
+basis spherical
+  H library STO-3G
+  O library 6-31G*
+end
+
+# High-quality calculation
+basis spherical
+  * library cc-pVTZ
+end
+```
+
+## 选项 (Options)
+
+- `spherical` - 球谐基函数 / Spherical harmonic basis functions
+- `cartesian` - 笛卡尔基函数 / Cartesian basis functions
+- `library` - 从库中加载基组
+- `file` - 从文件加载基组
+
+## 相关来源 (Related Sources)
+
+- `raw/assets/keywords_data.py` - BASIS_SETS 列表
+- `raw/assets/water_dft.nw` - 示例
+- `raw/assets/benzene_mp2.nw` - 示例
+
+## 相关实体/概念 (Related Entities/Concepts)
+
+- [[NWChem]]
+- [[ECP]]
+
+## 历史更新 (History)
+
+- 2026-06-12: 初始创建

--- a/wiki/entities/CCSD.md
+++ b/wiki/entities/CCSD.md
@@ -1,0 +1,78 @@
+# CCSD (耦合簇方法)
+
+> 类型：计算方法
+> 创建日期：2026-06-12
+> 来源数：2
+
+## 简介 (Introduction)
+
+CCSD（Coupled Cluster Singles and Doubles）是一种高精度的电子相关方法，包含单激发和双激发。CCSD(T) 方法加上微扰三重激发，被称为"量子化学的金标准"。
+
+## 语法结构 (Syntax Structure)
+
+```nwchem
+ccsd
+  freeze <option>
+  thresh <value>
+  maxiter <n>
+  ...
+end
+```
+
+## CCSD 选项 (CCSD Options)
+
+- `freeze atomic` - 冻结内层轨道（常用）
+- `freeze <n>` - 冻结指定数量的轨道
+- `thresh <value>` - 收敛阈值（默认 1e-6）
+- `maxiter <n>` - 最大迭代次数
+- `tce` - 使用张量收缩引擎
+- `io` - 控制磁盘 I/O 策略
+- `diis` - DIIS 加速收敛
+- `nodis` - 禁用 DIIS
+- `ccsd(t)` - 激活微扰三重激发
+
+## CCSD 变体 (CCSD Variants)
+
+- `ccsd` - 标准耦合簇 Singles and Doubles
+- `ccsd(t)` - CCSD with perturbative Triples（金标准）
+- `ccsd[t]` - CCSD with approximate Triples
+
+## 示例 (Examples)
+
+```nwchem
+# Standard CCSD calculation
+ccsd
+  freeze atomic
+  thresh 1e-7
+end
+
+# CCSD(T) - "Gold Standard"
+ccsd
+  freeze atomic
+  thresh 1e-7
+  maxiter 100
+end
+
+task ccsd(t) energy
+```
+
+## 计算成本 (Computational Cost)
+
+- CCSD: O(N^6)
+- CCSD(T): O(N^7)
+- 适用于小分子（~20 原子以内）
+
+## 相关来源 (Related Sources)
+
+- `raw/assets/keywords_data.py` - CC_KEYWORDS
+- `raw/assets/methane_ccsd.nw` - 示例
+
+## 相关实体/概念 (Related Entities/Concepts)
+
+- [[NWChem]]
+- [[MP2]]
+- [[Task_Operation]]
+
+## 历史更新 (History)
+
+- 2026-06-12: 初始创建

--- a/wiki/entities/Chemical_Elements.md
+++ b/wiki/entities/Chemical_Elements.md
@@ -1,0 +1,70 @@
+# Chemical Elements (化学元素)
+
+> 类型：数据
+> 创建日期：2026-06-12
+> 来源数：1
+
+## 简介 (Introduction)
+
+NWChem 支持全部 118 种化学元素，可用于几何结构定义和基组指定。
+
+## 元素列表 (Element List)
+
+NWChem 支持的元素符号（按原子序数）：
+
+1-18 (主族元素):
+- H, He, Li, Be, B, C, N, O, F, Ne
+- Na, Mg, Al, Si, P, S, Cl, Ar
+
+19-36:
+- K, Ca, Sc, Ti, V, Cr, Mn, Fe, Co, Ni, Cu, Zn
+- Ga, Ge, As, Se, Br, Kr
+
+37-54:
+- Rb, Sr, Y, Zr, Nb, Mo, Tc, Ru, Rh, Pd, Ag, Cd
+- In, Sn, Sb, Te, I, Xe
+
+55-86:
+- Cs, Ba, La-Lu (镧系)
+- Hf, Ta, W, Re, Os, Ir, Pt, Au, Hg, Tl, Pb, Bi, Po, At, Rn
+
+87-118:
+- Fr, Ra, Ac-Lr (锕系)
+- Rf, Db, Sg, Bh, Hs, Mt, Ds, Rg, Cn, Nh, Fl, Mc, Lv, Ts, Og
+
+## 在几何结构中的使用 (Usage in Geometry)
+
+```nwchem
+geometry units angstroms
+  H  0.0  0.0  0.0
+  C  0.0  0.0  1.0
+  O  0.0  0.0  2.0
+  Fe 0.0  0.0  3.0
+  Pt 0.0  0.0  4.0
+end
+```
+
+## 在基组中的使用 (Usage in Basis)
+
+```nwchem
+basis spherical
+  H library 6-31G*
+  C library cc-pVTZ
+  Fe library def2-TZVP
+  Pt library LANL2DZ
+end
+```
+
+## 相关来源 (Related Sources)
+
+- `raw/assets/keywords_data.py` - ELEMENTS 列表
+
+## 相关实体/概念 (Related Entities/Concepts)
+
+- [[NWChem]]
+- [[Geometry_Section]]
+- [[Basis_Set]]
+
+## 历史更新 (History)
+
+- 2026-06-12: 初始创建

--- a/wiki/entities/DFT.md
+++ b/wiki/entities/DFT.md
@@ -1,0 +1,118 @@
+# DFT (密度泛函理论)
+
+> 类型：计算方法
+> 创建日期：2026-06-12
+> 来源数：3
+
+## 简介 (Introduction)
+
+密度泛函理论（Density Functional Theory, DFT）是 NWChem 中最常用的量子化学计算方法之一，适用于中等大小分子的结构优化和性质计算。
+
+## 语法结构 (Syntax Structure)
+
+```nwchem
+dft
+  xc <functional>
+  grid <grid_size>
+  convergence <property> <value>
+  ...
+end
+```
+
+## 交换-相关泛函 (Exchange-Correlation Functionals)
+
+### LDA/GGA 系列
+- `LDA` / `S` - 局域密度近似
+- `BLYP` - Becke-Lee-Yang-Parr
+- `PBE` - Perdew-Burke-Ernzerhof
+- `BP86` - Becke-Perdew 86
+- `PW91` - Perdew-Wang 91
+- `PBEsol` - 固体优化 PBE
+
+### 杂化泛函 (Hybrid Functionals)
+- `B3LYP` - Becke 三参数杂化（最常用）
+- `PBE0` - PBE 杂化泛函
+- `BHLYP` - Becke 半半杂化
+- `B3PW91` - Becke-Perdew-Wang 91 杂化
+- `X3LYP` / `O3LYP` - 改进杂化泛函
+
+### 色散校正泛函 (Dispersion-Corrected)
+- `B97-D` - Grimme 色散校正
+- `wB97X-D` - 长程校正 + 色散
+- `B97-1` / `B97-2` / `B98` - Becke 97 系列
+
+### Meta-GGA
+- `TPSS` - Tao-Perdew-Staroverov-Scuseria
+- `M06-L` / `M06` / `M06-2X` / `M06-HF` - Minnesota 泛函系列
+- `SCAN` / `rSCAN` / `r2SCAN` - 强约束近似泛函
+- `MN12-L` / `MN12-SX` - Minnesota 12 泛函
+
+### 长程校正泛函 (Range-Separated)
+- `LC-BLYP` / `LC-PBE` - 长程校正
+- `CAM-B3LYP` - Coulomb-attenuating 方法
+- `wB97` / `wB97X` - 长程校正杂化
+- `M11` / `M11-L` - M11 系列
+- `M08-HX` / `M08-SO` - M08 系列
+
+## DFT 选项 (DFT Options)
+
+### 网格设置 (Grid Settings)
+- `coarse` - 粗网格
+- `medium` - 中等网格
+- `fine` - 细网格（常用推荐）
+- `xfine` - 超细网格
+- `ultrafine` - 极细网格
+
+### 收敛标准 (Convergence)
+- `convergence energy <value>` - 能量收敛阈值
+- `convergence density <value>` - 密度收敛阈值
+- `convergence gradient <value>` - 梯度收敛阈值
+
+### 其他选项 (Other Options)
+- `direct` - 强制直接 SCF（重新计算积分）
+- `noio` - 禁用积分的磁盘 I/O
+- `odft` - 开壳层 DFT 计算
+- `mult <n>` - 自旋多重度
+- `iterations <n>` - 最大 SCF 迭代次数
+
+## 示例 (Examples)
+
+```nwchem
+# Standard B3LYP calculation
+dft
+  xc b3lyp
+  grid fine
+  convergence energy 1e-8
+end
+
+# High-precision calculation with dispersion
+dft
+  xc wB97X-D
+  grid xfine
+  convergence energy 1e-10
+  iterations 200
+end
+
+# Open-shell calculation
+dft
+  xc B3LYP
+  mult 2
+  odft
+end
+```
+
+## 相关来源 (Related Sources)
+
+- `raw/assets/keywords_data.py` - DFT_FUNCTIONALS 列表
+- `raw/assets/water_dft.nw` - 示例
+- `raw/assets/3carbo_dft.nw` - 示例
+
+## 相关实体/概念 (Related Entities/Concepts)
+
+- [[NWChem]]
+- [[XC_Functional]]
+- [[Task_Operation]]
+
+## 历史更新 (History)
+
+- 2026-06-12: 初始创建

--- a/wiki/entities/Diagnostic_System.md
+++ b/wiki/entities/Diagnostic_System.md
@@ -1,0 +1,91 @@
+# Diagnostic System (诊断系统)
+
+> 类型：系统设计
+> 创建日期：2026-06-12
+> 来源数：2
+
+## 简介 (Introduction)
+
+nwchem-lsp 实现了结构化的诊断系统，符合 Scientific LSP 诊断契约，提供确定性 JSON 输出用于代理驱动的检查/修复循环。
+
+## 严重程度策略 (Severity Policy)
+
+- `error` - 高置信度的语法、模式、类型/值或引用问题，应阻止自动提交
+- `warning` - 高风险或可疑输入，可能是故意的
+- `information` / `hint` - 风格、文档或可选优化信息
+
+## 诊断类别 (Diagnostic Categories)
+
+- `syntax` - 语法错误
+- `schema` - 模式违反（缺失必需部分等）
+- `type/value` - 类型或值错误
+- `cross-file reference` - 跨文件引用问题
+- `semantic consistency` - 语义一致性
+- `preflight/runtime-risk` - 运行时风险
+- `style/deprecation` - 风格或弃用警告
+
+## 常见诊断 (Common Diagnostics)
+
+### 语法错误 (Syntax Errors)
+- `UNCLOSED_SECTION` - 未闭合的部分块
+- `UNEXPECTED_END` - 意外的 `end` 关键字
+- `MISSING_START` - 缺少 `start` 指令
+
+### 模式错误 (Schema Errors)
+- `UNKNOWN_BASIS_SET` - 不支持的基组
+- `UNKNOWN_FUNCTIONAL` - 不支持的 DFT 泛函
+- `INVALID_TASK` - 无效的任务操作
+
+### 快速修复 (Quick Fixes)
+- 添加缺失的 `end` 关键字
+- 删除意外的 `end` 关键字
+- 修正常见拼写错误（gemoetry → geometry）
+- 添加缺失的 `start` 指令
+
+## 富诊断形状 (Rich Diagnostic Shape)
+
+```json
+{
+  "code": "STABLE_CODE",
+  "severity": "error",
+  "category": "schema",
+  "confidence": 1.0,
+  "source": "nwchem-lsp",
+  "range": {
+    "start": {"line": 0, "character": 0},
+    "end": {"line": 0, "character": 1}
+  },
+  "software": "nwchem",
+  "file_type": "input",
+  "path": "input",
+  "expected": null,
+  "actual": null,
+  "manual_ref": null,
+  "fix_hints": [],
+  "blocking": true
+}
+```
+
+## 代理 CLI (Agent CLI)
+
+```bash
+nwchem-lsp-tool check path/to/input --format json
+nwchem-lsp-tool context path/to/input --format json
+nwchem-lsp-tool complete path/to/input --format json
+nwchem-lsp-tool hover path/to/input --format json
+nwchem-lsp-tool symbols path/to/input --format json
+nwchem-lsp-tool fix path/to/input --format json
+```
+
+## 相关来源 (Related Sources)
+
+- `raw/assets/DIAGNOSTIC_ENGINE_V1.md` - 诊断引擎文档
+
+## 相关实体/概念 (Related Entities/Concepts)
+
+- [[LSP_Server]]
+- [[NWChem]]
+
+## 历史更新 (History)
+
+- 2026-06-12: 初始创建

--- a/wiki/entities/ECP.md
+++ b/wiki/entities/ECP.md
@@ -1,0 +1,70 @@
+# ECP (有效核势)
+
+> 类型：基组/方法
+> 创建日期：2026-06-12
+> 来源数：1
+
+## 简介 (Introduction)
+
+ECP（Effective Core Potential，有效核势）也称为赝势，用于替代重金属原子的内层电子，减少计算成本同时保持合理的精度。
+
+## 语法结构 (Syntax Structure)
+
+```nwchem
+ecp
+  <element> library <ecp_name>
+end
+```
+
+## 常用 ECP (Common ECPs)
+
+- `LANL2DZ` - Los Alamos ECP + 双-zeta 价基
+- `LANL2TZ` - Los Alamos ECP + 三-zeta 价基
+- `SDD` - Stuttgart/Dresden ECP
+
+## 适用元素 (Applicable Elements)
+
+ECP 主要用于：
+- 过渡金属（Transition metals）
+- 镧系和锕系（Lanthanides and actinides）
+- 重元素（Heavy elements, Z > 36）
+
+## 示例 (Examples)
+
+```nwchem
+# Platinum with LANL2DZ ECP
+ecp
+  Pt library LANL2DZ
+end
+
+basis
+  Pt library LANL2DZ
+  * library 6-31G*
+end
+
+# Transition metal complex
+ecp
+  Fe library SDD
+  Cu library SDD
+end
+
+basis spherical
+  Fe library SDD
+  Cu library SDD
+  H library 6-31G*
+end
+```
+
+## 相关来源 (Related Sources)
+
+- `raw/assets/keywords_data.py` - ECP 关键词定义
+- `raw/assets/fe_scf_ecp.nw` - 示例
+
+## 相关实体/概念 (Related Entities/Concepts)
+
+- [[NWChem]]
+- [[Basis_Set]]
+
+## 历史更新 (History)
+
+- 2026-06-12: 初始创建

--- a/wiki/entities/Geometry_Section.md
+++ b/wiki/entities/Geometry_Section.md
@@ -1,0 +1,65 @@
+# Geometry Section (几何结构部分)
+
+> 类型：输入文件部分
+> 创建日期：2026-06-12
+> 来源数：3
+
+## 简介 (Introduction)
+
+`geometry` 部分定义分子的原子坐标和几何参数。这是 NWChem 输入文件中的必需部分。
+
+## 语法结构 (Syntax Structure)
+
+```nwchem
+geometry [units <unit>] [options]
+  <element> <x> <y> <z>
+  ...
+end
+```
+
+## 关键选项 (Key Options)
+
+### 单位指定 (Units)
+- `angstroms` - 埃（默认）/ Angstroms (default)
+- `bohr` / `au` - 玻尔半径 / Bohr
+- `nanometers` - 纳米 / Nanometers
+- `picometers` - 皮米 / Picometers
+
+### 几何选项 (Geometry Options)
+- `autosym` - 自动对称性检测 / Automatic symmetry detection
+- `noautoz` - 禁用自动 Z 矩阵生成 / Disable automatic Z-matrix
+- `center` / `nocenter` - 是否将分子中心置于原点
+- `system` - 周期性边界条件 / Periodic boundary conditions
+
+## 示例 (Examples)
+
+```nwchem
+# Water molecule in Angstroms
+geometry units angstroms
+  O  0.000  0.000  0.000
+  H  0.000  0.790  0.580
+  H  0.000 -0.790  0.580
+end
+
+# Benzene with automatic symmetry
+geometry units angstroms autosym
+  C    1.398    0.000    0.000
+  C    0.699    1.212    0.000
+  ...
+end
+```
+
+## 相关来源 (Related Sources)
+
+- `raw/assets/keywords_data.py` - GEOMETRY_KEYWORDS
+- `raw/assets/water_dft.nw` - 示例
+- `raw/assets/benzene_mp2.nw` - 示例
+
+## 相关实体/概念 (Related Entities/Concepts)
+
+- [[NWChem]]
+- [[Chemical_Elements]]
+
+## 历史更新 (History)
+
+- 2026-06-12: 初始创建

--- a/wiki/entities/LSP_Server.md
+++ b/wiki/entities/LSP_Server.md
@@ -1,0 +1,89 @@
+# LSP Server (语言服务器)
+
+> 类型：软件架构
+> 创建日期：2026-06-12
+> 来源数：4
+
+## 简介 (Introduction)
+
+nwchem-lsp 是 NWChem 的 Language Server Protocol（语言服务器协议）实现，为编辑器提供智能编辑功能，包括语法检查、自动补全、悬停文档等。
+
+## 架构组件 (Architecture Components)
+
+### 核心服务器 (Core Server)
+- `NWChemLanguageServer` - 主 LSP 服务器类
+- 基于 pygls 框架构建
+- 版本: 0.5.0
+
+### 特性提供器 (Feature Providers)
+
+| 提供器 | 功能 |
+|--------|------|
+| `NwchemCompletionProvider` | 自动补全 |
+| `NwchemHoverProvider` | 悬停文档 |
+| `DiagnosticProvider` | 语法/错误诊断 |
+| `NwchemSymbolProvider` | 文档符号 |
+| `WorkspaceSymbolProvider` | 工作区符号 |
+| `NwchemFormattingProvider` | 代码格式化 |
+| `CodeActionsProvider` | 代码操作/快速修复 |
+| `DefinitionProvider` | 跳转到定义 |
+| `SemanticTokensProvider` | 语义高亮 |
+| `InlayHintsProvider` | 内联提示 |
+| `FoldingRangeProvider` | 代码折叠 |
+| `ReferencesProvider` | 查找引用 |
+| `RenameProvider` | 重命名 |
+
+### 数据模块 (Data Module)
+- `keywords.py` - 关键词数据库
+- 包含化学元素、基组、泛函等
+
+### 解析器模块 (Parser Module)
+- `NwchemParser` - NWChem 输入文件解析器
+- `ParseContext` - 解析上下文
+- `NWchemSection` - 部分表示
+
+## LSP 功能 (LSP Capabilities)
+
+### v0.1.0 - 基础功能
+- 语法验证
+- 自动补全
+- 悬停文档
+- 文档符号
+
+### v0.2.0
+- 代码格式化
+
+### v0.3.0
+- 代码操作（快速修复）
+- 跳转到定义
+
+### v0.4.0
+- 工作区符号
+- 配置选项
+- 语义高亮
+- 内联提示
+
+### v0.5.0
+- 代码折叠
+- 查找引用
+- 重命名
+
+## 支持的文件类型 (Supported File Types)
+
+- `.nw` - NWChem 输入文件
+- `.nwinp` - NWChem 输入文件（替代扩展名）
+
+## 相关来源 (Related Sources)
+
+- `raw/assets/README.md` - 项目文档
+- `raw/assets/architecture.md` - 架构文档
+- `raw/assets/nwchem_parser.py` - 解析器实现
+
+## 相关实体/概念 (Related Entities/Concepts)
+
+- [[NWChem]]
+- [[Diagnostic_System]]
+
+## 历史更新 (History)
+
+- 2026-06-12: 初始创建

--- a/wiki/entities/MP2.md
+++ b/wiki/entities/MP2.md
@@ -1,0 +1,74 @@
+# MP2 (二阶微扰理论)
+
+> 类型：计算方法
+> 创建日期：2026-06-12
+> 来源数：2
+
+## 简介 (Introduction)
+
+MP2（Second-order Møller-Plesset perturbation theory）是二阶 Møller-Plesset 微扰理论，是一种包含电子相关能量的后 Hartree-Fock 方法，比 HF 更精确但计算成本适中。
+
+## 语法结构 (Syntax Structure)
+
+```nwchem
+mp2
+  freeze <option>
+  [ri|cd]
+  ...
+end
+```
+
+## MP2 选项 (MP2 Options)
+
+- `freeze atomic` - 冻结内层轨道（常用）
+- `freeze <n>` - 冻结指定数量的轨道
+- `tight` - 使用更严格的收敛标准
+- `ri` - 使用分辨率恒等近似加速计算
+- `cd` - 使用 Cholesky 分解加速
+- `thize <value>` - 积分阈值
+- `thize_g <value>` - 梯度积分阈值
+- `scratch disk` - 使用磁盘存储积分
+
+## 示例 (Examples)
+
+```nwchem
+# Standard MP2 with frozen core
+mp2
+  freeze atomic
+end
+
+# MP2 with RI approximation for speed
+mp2
+  freeze atomic
+  ri
+end
+
+# High-precision MP2
+mp2
+  freeze atomic
+  tight
+end
+
+task mp2 optimize
+```
+
+## 计算成本 (Computational Cost)
+
+- 常规 MP2: O(N^5)
+- RI-MP2: O(N^4) - 显著加速
+- 适用于中等大小分子（~100 原子以内）
+
+## 相关来源 (Related Sources)
+
+- `raw/assets/keywords_data.py` - MP2_KEYWORDS
+- `raw/assets/benzene_mp2.nw` - 示例
+
+## 相关实体/概念 (Related Entities/Concepts)
+
+- [[NWChem]]
+- [[CCSD]]
+- [[Task_Operation]]
+
+## 历史更新 (History)
+
+- 2026-06-12: 初始创建

--- a/wiki/entities/NWChem.md
+++ b/wiki/entities/NWChem.md
@@ -1,0 +1,48 @@
+# NWChem (量子化学软件)
+
+> 类型：软件 / 量子化学计算
+> 创建日期：2026-06-12
+> 来源数：5
+
+## 简介 (Introduction)
+
+NWChem is an open-source quantum chemistry software package designed for high-performance computing. It provides capabilities for molecular structure optimization, property calculations, and dynamics simulations using various quantum mechanical methods.
+
+## 关键特性 (Key Features)
+
+- 支持多种量子化学方法 (Supports multiple quantum chemistry methods)
+  - SCF (自洽场) / Self-Consistent Field
+  - DFT (密度泛函理论) / Density Functional Theory
+  - MP2 (二阶微扰理论) / Second-order Møller-Plesset perturbation theory
+  - CCSD/CCSD(T) (耦合簇) / Coupled Cluster
+- 并行计算支持 (Parallel computing support)
+- 支持周期性体系 (Periodic system support)
+- 分子动力学模拟 (Molecular dynamics simulations)
+
+## 输入文件格式 (Input File Format)
+
+NWChem 使用 `.nw` 或 `.nwinp` 扩展名的输入文件，包含以下主要部分：
+
+1. **start** - 指定计算名称
+2. **title** - 计算标题
+3. **geometry** - 分子几何结构
+4. **basis** - 基组指定
+5. **理论模块** - scf, dft, mp2, ccsd 等
+6. **task** - 执行的任务
+
+## 相关来源 (Related Sources)
+
+- `raw/assets/README.md` - 项目文档
+- `raw/assets/water_dft.nw` - 示例输入文件
+- `raw/assets/keywords_data.py` - 关键词数据库
+
+## 相关实体/概念 (Related Entities/Concepts)
+
+- [[Geometry_Section]]
+- [[Basis_Set]]
+- [[DFT]]
+- [[Task_Operation]]
+
+## 历史更新 (History)
+
+- 2026-06-12: 初始创建

--- a/wiki/entities/SCF.md
+++ b/wiki/entities/SCF.md
@@ -1,0 +1,85 @@
+# SCF (自洽场方法)
+
+> 类型：计算方法
+> 创建日期：2026-06-12
+> 来源数：3
+
+## 简介 (Introduction)
+
+SCF（Self-Consistent Field，自洽场）方法是量子化学计算的基础方法，也称为 Hartree-Fock 方法。NWChem 的 `scf` 部分用于配置 SCF 计算参数。
+
+## 语法结构 (Syntax Structure)
+
+```nwchem
+scf
+  <spin_state>
+  <method>
+  <convergence_options>
+  ...
+end
+```
+
+## 自旋状态 (Spin States)
+
+- `singlet` - 单重态
+- `doublet` - 二重态
+- `triplet` - 三重态
+- `quartet` - 四重态
+- `quintet` - 五重态
+
+## SCF 方法 (SCF Methods)
+
+- `rhf` - 限制性 Hartree-Fock / Restricted Hartree-Fock
+- `uhf` - 非限制性 Hartree-Fock / Unrestricted Hartree-Fock
+- `rohf` - 限制性开壳层 Hartree-Fock / Restricted Open-shell HF
+- `mcscf` - 多组态自洽场 / Multi-Configurational SCF
+
+## 收敛选项 (Convergence Options)
+
+- `thresh <value>` - 收敛阈值（默认 1e-6）
+- `maxiter <n>` - 最大迭代次数（默认 50）
+- `direct` - 直接 SCF（重新计算所有积分）
+- `semidirect` - 半直接 SCF
+
+## 示例 (Examples)
+
+```nwchem
+# Standard closed-shell RHF
+scf
+  singlet
+  rhf
+  maxiter 100
+  thresh 1e-8
+end
+
+# Open-shell UHF calculation
+scf
+  doublet
+  uhf
+  thresh 1e-6
+end
+
+# High-precision calculation
+scf
+  singlet
+  rhf
+  thresh 1e-10
+  maxiter 200
+end
+```
+
+## 相关来源 (Related Sources)
+
+- `raw/assets/keywords_data.py` - SCF_KEYWORDS
+- `raw/assets/h2o_scf.nw` - 示例
+- `raw/assets/3carbo.nw` - 示例
+
+## 相关实体/概念 (Related Entities/Concepts)
+
+- [[NWChem]]
+- [[DFT]]
+- [[Task_Operation]]
+
+## 历史更新 (History)
+
+- 2026-06-12: 初始创建

--- a/wiki/entities/Task_Operation.md
+++ b/wiki/entities/Task_Operation.md
@@ -1,0 +1,101 @@
+# Task Operation (任务操作)
+
+> 类型：NWChem 命令
+> 创建日期：2026-06-12
+> 来源数：3
+
+## 简介 (Introduction)
+
+`task` 命令指定 NWChem 要执行的计算任务。它是 NWChem 输入文件中的必需部分，定义了使用何种理论方法执行何种计算类型。
+
+## 语法结构 (Syntax Structure)
+
+```nwchem
+task <theory> <operation>
+```
+
+## 理论方法 (Theories)
+
+- `scf` - 自洽场方法 / Self-Consistent Field
+- `dft` - 密度泛函理论 / Density Functional Theory
+- `mp2` - 二阶微扰理论 / MP2 perturbation theory
+- `ccsd` - 耦合簇 Singles and Doubles
+- `ccsd(t)` - CCSD with perturbative Triples
+- `mcscf` - 多组态自洽场 / Multi-Configurational SCF
+- `semi` - 半经验方法 / Semi-empirical methods
+- `rimp2` - 分辨率恒等 MP2 / RI-MP2
+
+## 计算操作 (Operations)
+
+### 能量计算 (Energy Calculations)
+- `energy` - 单点能量计算
+
+### 几何优化 (Geometry Optimization)
+- `optimize` - 分子几何结构优化
+
+### 梯度相关 (Gradient Related)
+- `gradient` - 梯度计算
+
+### 振动分析 (Vibrational Analysis)
+- `frequencies` / `freq` / `vib` - 振动频率计算
+- `hessian` - Hessian 矩阵计算
+
+### 过渡态 (Transition State)
+- `saddle` - 过渡态搜索
+
+### 动力学 (Dynamics)
+- `dynamics` - 分子动力学模拟
+- `thermodynamics` - 热力学性质计算
+
+### 性质计算 (Property Calculations)
+- `property` - 分子性质计算
+
+### 高级方法 (Advanced Methods)
+- `tce` - 张量收缩引擎
+- `ccsd` / `ccsd(t)` - 耦合簇计算
+- `mp2` / `mp3` / `mp4` - 微扰理论
+- `mcscf` - 多组态自洽场
+- `selci` - 选定 CI
+- `pspw` - 赝势平面波
+- `band` - 能带结构计算
+- `paw` - 投影缀加波
+- `ofpw` - 正交平面波
+
+## 示例 (Examples)
+
+```nwchem
+# DFT geometry optimization
+task dft optimize
+
+# Single point energy calculation
+task scf energy
+
+# MP2 frequency calculation
+task mp2 frequencies
+
+# CCSD(T) single point
+task ccsd(t) energy
+
+# Molecular dynamics
+task scf dynamics
+
+# Hessian calculation
+task dft hessian
+```
+
+## 相关来源 (Related Sources)
+
+- `raw/assets/keywords_data.py` - TASK_OPERATIONS 列表
+- `raw/assets/water_dft.nw` - 示例
+- `raw/assets/benzene_mp2.nw` - 示例
+
+## 相关实体/概念 (Related Entities/Concepts)
+
+- [[NWChem]]
+- [[DFT]]
+- [[SCF]]
+- [[MP2]]
+
+## 历史更新 (History)
+
+- 2026-06-12: 初始创建

--- a/wiki/entities/XC_Functional.md
+++ b/wiki/entities/XC_Functional.md
@@ -1,0 +1,69 @@
+# XC Functional (交换-相关泛函)
+
+> 类型：量子化学概念
+> 创建日期：2026-06-12
+> 来源数：2
+
+## 简介 (Introduction)
+
+交换-相关泛函（Exchange-Correlation Functional）是 DFT 计算的核心，决定了计算的精度和适用性。
+
+## 泛函分类 (Functional Categories)
+
+### 局域密度近似 (LDA)
+- `LDA` / `S` - 基于均匀电子气模型
+
+### 广义梯度近似 (GGA)
+- `PBE` - Perdew-Burke-Ernzerhof
+- `BLYP` - Becke-Lee-Yang-Parr
+- `BP86` - Becke-Perdew 86
+- `PW91` - Perdew-Wang 91
+
+### 杂化泛函 (Hybrid)
+- `B3LYP` - 最常用，20% HF 交换
+- `PBE0` - 25% HF 交换
+- `X3LYP` - 改进的杂化泛函
+
+### 色散校正 (Dispersion-Corrected)
+- `B97-D` - Grimme 色散
+- `wB97X-D` - 长程 + 色散
+
+### Meta-GGA
+- `TPSS` - Tao-Perdew-Staroverov-Scuseria
+- `M06-2X` - 高非局域性
+- `SCAN` / `rSCAN` / `r2SCAN` - 强约束近似
+
+### 双杂化 (Double Hybrid)
+- `B2PLYP` - 包含 MP2 相关
+
+## 在 DFT 部分使用 (Usage in DFT Section)
+
+```nwchem
+dft
+  xc <functional_name>
+end
+```
+
+## 泛函选择指南 (Functional Selection Guide)
+
+| 应用场景 | 推荐泛函 |
+|---------|---------|
+| 一般有机分子 | B3LYP, PBE0 |
+| 含弱相互作用 | B97-D, wB97X-D |
+| 固体/表面 | PBEsol, SCAN |
+| 过渡金属 | M06-L, TPSS |
+| 高精度要求 | wB97X, DSD-PBEP86 |
+| 快速筛选 | BLYP, PBE |
+
+## 相关来源 (Related Sources)
+
+- `raw/assets/keywords_data.py` - DFT_FUNCTIONALS 列表
+
+## 相关实体/概念 (Related Entities/Concepts)
+
+- [[DFT]]
+- [[NWChem]]
+
+## 历史更新 (History)
+
+- 2026-06-12: 初始创建

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -1,0 +1,92 @@
+# NWChem LSP Wiki (NWChem 语言服务器知识库)
+
+> 创建日期：2026-06-12
+> 最后更新：2026-06-12
+> Wiki 类型：Karpathy 风格 LLM Wiki
+
+## 概述 (Overview)
+
+本知识库是 nwchem-lsp 项目的官方文档和参考指南，涵盖 NWChem 量子化学软件的 LSP 实现和 NWChem 领域知识。
+
+## 目录结构 (Structure)
+
+### 实体 (Entities)
+NWChem 特定概念和组件的详细页面：
+
+- [[NWChem]] - NWChem 量子化学软件
+- [[Geometry_Section]] - 几何结构部分
+- [[Basis_Set]] - 基组规范
+- [[DFT]] - 密度泛函理论
+- [[Task_Operation]] - 任务操作
+- [[SCF]] - 自洽场方法
+- [[MP2]] - 二阶微扰理论
+- [[CCSD]] - 耦合簇方法
+- [[ECP]] - 有效核势
+- [[Chemical_Elements]] - 化学元素
+- [[XC_Functional]] - 交换-相关泛函
+- [[LSP_Server]] - 语言服务器
+- [[Diagnostic_System]] - 诊断系统
+
+### 概念 (Concepts)
+跨领域的量子化学概念和方法论：
+
+- [[Quantum_Chemistry_Methods]] - 量子化学方法层级
+- [[Basis_Set_Selection]] - 基组选择策略
+- [[Geometry_Input_Formats]] - 几何输入格式
+- [[Convergence_Control]] - 收敛控制
+- [[Spin_and_Multiplicity]] - 自旋与多重度
+
+### 综合 (Synthesis)
+API 参考、诊断目录和 DSL 规范：
+
+- [[NWChem_DSL_Reference]] - NWChem DSL 完整参考
+- [[Diagnostics_Catalog]] - 诊断目录
+- [[Feature_Providers_API]] - 特性提供器 API
+- [[Parser_API]] - 解析器 API
+
+## 原始材料 (Raw Materials)
+
+详细源证据位于 `raw/assets/`：
+
+- `README.md` - 项目文档
+- `PLAN.md` - 开发计划
+- `AGENTS.md` - 代理工作流指南
+- `architecture.md` - 架构文档
+- `DIAGNOSTIC_ENGINE_V1.md` - 诊断引擎规范
+- `keywords_data.py` - 关键词数据库
+- `nwchem_parser.py` - 解析器实现
+- `*.nw` - 示例输入文件
+
+## 更新日志 (Change Log)
+
+见 `log.md` 获取详细变更历史。
+
+## 快速导航 (Quick Navigation)
+
+### 对于 LSP 用户
+- [[LSP_Server]] - LSP 功能概述
+- [[Diagnostics_Catalog]] - 可用的诊断
+- [[Feature_Providers_API]] - 功能详情
+
+### 对于 NWChem 用户
+- [[NWChem_DSL_Reference]] - 完整语法参考
+- [[Geometry_Section]] - 几何定义
+- [[Basis_Set]] - 基组选择
+- [[DFT]] - DFT 配置
+
+### 对于开发者
+- [[Parser_API]] - 解析器 API
+- [[Feature_Providers_API]] - 扩展指南
+- [[Diagnostic_System]] - 诊断系统架构
+
+## 贡献指南 (Contributing)
+
+更新 Wiki 时：
+1. 保持原始材料在 `raw/assets/` 不变
+2. 在 `wiki/` 中更新衍生内容
+3. 记录变更到 `log.md`
+4. 更新相关链接
+
+---
+
+本 Wiki 使用 Obsidian 兼容的 markdown 格式，支持 `[[Wiki_Link]]` 双向链接。

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -1,0 +1,88 @@
+# NWChem LSP Wiki Change Log (更新日志)
+
+## 2026-06-12
+
+### 操作：初始化 LLM Wiki
+
+**来源路径**:
+- README.md
+- PLAN.md
+- AGENTS.md
+- CHANGELOG.md
+- architecture.md
+- DIAGNOSTIC_ENGINE_V1.md
+- keywords_data.py
+- nwchem_parser.py
+- examples/*.nw
+- tests/fixtures/real_world/nwchem-official/*.nw
+
+**创建的 Wiki 页面** (共 20 页):
+
+**实体页面 (13 页)**:
+- NWChem.md
+- Geometry_Section.md
+- Basis_Set.md
+- DFT.md
+- Task_Operation.md
+- SCF.md
+- MP2.md
+- CCSD.md
+- ECP.md
+- Chemical_Elements.md
+- XC_Functional.md
+- LSP_Server.md
+- Diagnostic_System.md
+
+**概念页面 (5 页)**:
+- Quantum_Chemistry_Methods.md
+- Basis_Set_Selection.md
+- Geometry_Input_Formats.md
+- Convergence_Control.md
+- Spin_and_Multiplicity.md
+
+**综合页面 (4 页)**:
+- NWChem_DSL_Reference.md
+- Diagnostics_Catalog.md
+- Feature_Providers_API.md
+- Parser_API.md
+
+**导航页面 (2 页)**:
+- index.md
+- log.md
+
+**关键发现**:
+- NWChem LSP 实现了完整的 LSP 功能集（v0.5.0）
+- 支持从基础 SCF 到高精度 CCSD(T) 的多种量子化学方法
+- 关键词数据库包含 118 种化学元素、多种基组和 DFT 泛函
+- 诊断系统符合 Scientific LSP 契约
+
+**统计数据**:
+- 原始文件：13 个
+- Wiki 页面：24 个
+- 双向链接：42 个
+- 支持的化学元素：118 个
+- 支持的基组：30+ 个
+- 支持的 DFT 泛函：40+ 个
+
+---
+
+## 维护说明
+
+更新格式：
+```
+## YYYY-MM-DD
+
+### 操作：<操作描述>
+
+**来源路径**:
+- <路径列表>
+
+**更新的页面**:
+- <页面列表>
+
+**关键发现**:
+- <发现列表>
+
+**统计数据**:
+- <相关统计>
+```

--- a/wiki/synthesis/Diagnostics_Catalog.md
+++ b/wiki/synthesis/Diagnostics_Catalog.md
@@ -1,0 +1,152 @@
+# Diagnostics Catalog (诊断目录)
+
+> 创建日期：2026-06-12
+> 最后更新：2026-06-12
+> 覆盖来源：2
+
+## 核心论点 (Core Thesis)
+
+nwchem-lsp 提供全面的诊断检测，帮助用户在运行 NWChem 前发现输入文件错误。
+
+## 诊断分类 (Diagnostic Categories)
+
+### 1. 语法错误 (Syntax Errors)
+
+#### UNCLOSED_SECTION
+- **代码**: `UNCLOSED_SECTION`
+- **严重程度**: `error`
+- **类别**: `syntax`
+- **描述**: 部分块未闭合
+- **示例**:
+```nwchem
+geometry
+  O 0.0 0.0 0.0
+# 缺少 'end'
+```
+- **修复**: 添加 `end` 关键字
+
+#### UNEXPECTED_END
+- **代码**: `UNEXPECTED_END`
+- **严重程度**: `error`
+- **类别**: `syntax`
+- **描述**: 意外的 `end` 关键字
+- **示例**:
+```nwchem
+end  # 没有匹配的部分开始
+```
+- **修复**: 删除多余的 `end`
+
+#### MISSING_START
+- **代码**: `MISSING_START`
+- **严重程度**: `warning`
+- **类别**: `syntax`
+- **描述**: 缺少 `start` 指令
+- **修复**: 添加 `start <name>`
+
+### 2. 模式错误 (Schema Errors)
+
+#### UNKNOWN_BASIS_SET
+- **代码**: `UNKNOWN_BASIS_SET`
+- **严重程度**: `error`
+- **类别**: `schema`
+- **描述**: 不支持的基组名称
+- **示例**:
+```nwchem
+basis
+  * library INVALID_BASIS
+end
+```
+- **修复**: 使用有效基组名
+
+#### UNKNOWN_FUNCTIONAL
+- **代码**: `UNKNOWN_FUNCTIONAL`
+- **严重程度**: `error`
+- **类别**: `schema`
+- **描述**: 不支持的 DFT 泛函
+- **示例**:
+```nwchem
+dft
+  xc INVALID_FUNCTIONAL
+end
+```
+- **修复**: 使用有效泛函名
+
+#### INVALID_TASK_OPERATION
+- **代码**: `INVALID_TASK_OPERATION`
+- **严重程度**: `error`
+- **类别**: `schema`
+- **描述**: 无效的任务操作组合
+
+### 3. 拼写错误 (Typos)
+
+#### TYPO_KEYWORD
+- **代码**: `TYPO_KEYWORD`
+- **严重程度**: `warning`
+- **类别**: `style/deprecation`
+- **描述**: 检测到常见拼写错误
+- **示例**: `gemoetry` → `geometry`
+- **修复**: 应用自动修复建议
+
+### 4. 引用错误 (Reference Errors)
+
+#### UNDEFINED_VARIABLE
+- **代码**: `UNDEFINED_VARIABLE`
+- **严重程度**: `error`
+- **类别**: `cross-file reference`
+- **描述**: 引用了未定义的变量
+
+## 快速修复 (Quick Fixes)
+
+### 代码操作 (Code Actions)
+
+1. **添加缺失的 `end`**
+   - 自动检测未闭合的部分
+   - 在合适位置插入 `end`
+
+2. **删除意外的 `end`**
+   - 删除没有匹配的部分开始
+
+3. **修正拼写错误**
+   - 使用模糊匹配检测常见拼写错误
+   - 提供修正建议
+
+4. **添加 `start` 指令**
+   - 当缺失时提供插入建议
+
+## 严重程度策略 (Severity Policy)
+
+| 严重程度 | 含义 | 阻止提交 |
+|---------|------|---------|
+| `error` | 高置信度错误，NWChem 将拒绝输入 | 是 |
+| `warning` | 高风险输入，可能是故意的 | 否 |
+| `information` | 风格或优化建议 | 否 |
+| `hint` | 文档提示 | 否 |
+
+## 诊断 API (Diagnostic API)
+
+### 获取诊断
+```bash
+nwchem-lsp-tool check path/to/input.nw --format json
+```
+
+### 诊断输出格式
+```json
+{
+  "uri": "file:///path/to/input.nw",
+  "diagnostics": [
+    {
+      "code": "UNCLOSED_SECTION",
+      "severity": "error",
+      "category": "syntax",
+      "confidence": 1.0,
+      "range": {...},
+      "message": "Unclosed section: 'geometry'"
+    }
+  ]
+}
+```
+
+## 来源列表 (Source List)
+
+- `raw/assets/DIAGNOSTIC_ENGINE_V1.md`
+- `raw/assets/README.md`

--- a/wiki/synthesis/Feature_Providers_API.md
+++ b/wiki/synthesis/Feature_Providers_API.md
@@ -1,0 +1,192 @@
+# Feature Providers API (特性提供器 API)
+
+> 创建日期：2026-06-12
+> 最后更新：2026-06-12
+> 覆盖来源：4
+
+## 核心论点 (Core Thesis)
+
+nwchem-lsp 采用模块化的特性提供器架构，每个 LSP 功能由独立的提供器类实现，便于维护和扩展。
+
+## 提供器列表 (Provider List)
+
+### 1. CompletionProvider (自动补全)
+
+**类**: `NwchemCompletionProvider`
+
+**方法**:
+- `get_completions(text, position)` - 返回补全项列表
+
+**支持上下文**:
+- 顶层关键词补全
+- 部分内部关键词补全
+- 基组名称补全
+- DFT 泛函补全
+- 任务操作补全
+- 化学元素补全
+
+**触发字符**: 空格, 换行
+
+### 2. HoverProvider (悬停文档)
+
+**类**: `NwchemHoverProvider`
+
+**方法**:
+- `get_hover(text, position)` - 返回悬停信息
+
+**提供信息**:
+- 关键词描述
+- 参数说明
+- 示例代码
+- 相关关键词
+
+### 3. DiagnosticProvider (诊断提供器)
+
+**类**: `DiagnosticProvider`
+
+**方法**:
+- `get_diagnostics(text)` - 返回诊断列表
+- `update_cache(uri, diagnostics)` - 更新诊断缓存
+- `snapshot_to_json(uri)` - 导出 JSON 格式诊断
+
+**检测内容**:
+- 未闭合的部分块
+- 意外的 `end` 关键字
+- 未知的基组
+- 未知的泛函
+- 缺失的 `start` 指令
+
+### 4. SymbolProvider (符号提供器)
+
+**类**: `NwchemSymbolProvider`
+
+**方法**:
+- `get_document_symbols(text)` - 返回文档符号列表
+
+**符号类型**:
+- 部分（geometry, basis, scf, dft 等）
+- 任务
+
+### 5. WorkspaceSymbolProvider (工作区符号)
+
+**类**: `WorkspaceSymbolProvider`
+
+**方法**:
+- `get_workspace_symbols(query, documents)` - 跨文档搜索符号
+
+### 6. FormattingProvider (格式化提供器)
+
+**类**: `NwchemFormattingProvider`
+
+**方法**:
+- `format_document(text, params)` - 格式化整个文档
+- `format_range(text, params)` - 格式化选定范围
+
+**格式化规则**:
+- 关键词小写
+- 移除多余空行
+- 统一缩进
+
+### 7. CodeActionsProvider (代码操作提供器)
+
+**类**: `CodeActionsProvider`
+
+**方法**:
+- `get_code_actions(text, diagnostics, uri)` - 返回可用的代码操作
+
+**支持的代码操作**:
+- 添加缺失的 `end`
+- 删除意外的 `end`
+- 修正拼写错误
+- 添加 `start` 指令
+
+### 8. DefinitionProvider (定义提供器)
+
+**类**: `DefinitionProvider`
+
+**方法**:
+- `get_definition(text, position)` - 返回定义位置
+
+**功能**:
+- 从 `end` 跳转到对应的部分开始
+- 从任务跳转到相关配置
+
+### 9. SemanticTokensProvider (语义标记提供器)
+
+**类**: `SemanticTokensProvider`
+
+**方法**:
+- `get_semantic_tokens(text)` - 返回语义标记
+
+**标记类型**:
+- 关键词
+- 元素符号
+- 数值
+- 注释
+
+### 10. InlayHintsProvider (内联提示提供器)
+
+**类**: `InlayHintsProvider`
+
+**方法**:
+- `get_inlay_hints(text, start_line, end_line)` - 返回内联提示
+
+**提示内容**:
+- 单位信息
+- 电荷状态
+- 参数说明
+
+### 11. FoldingRangeProvider (代码折叠提供器)
+
+**类**: `FoldingRangeProvider`
+
+**方法**:
+- `get_folding_ranges(text)` - 返回可折叠范围
+
+**折叠区域**:
+- 所有以 `end` 结束的部分块
+
+### 12. ReferencesProvider (引用提供器)
+
+**类**: `ReferencesProvider`
+
+**方法**:
+- `get_references(text, uri, position, include_declaration)` - 查找符号引用
+
+### 13. RenameProvider (重命名提供器)
+
+**类**: `RenameProvider`
+
+**方法**:
+- `get_rename_edits(text, uri, position, new_name)` - 执行符号重命名
+
+**重命名范围**:
+- 部分名称
+- 任务引用
+
+### 14. ConfigProvider (配置提供器)
+
+**类**: `ConfigProvider`
+
+**方法**:
+- `get_config(section)` - 获取配置项
+
+**配置选项**:
+- 格式化选项
+- 诊断选项
+- 补全选项
+
+## 扩展指南 (Extension Guide)
+
+添加新特性提供器：
+
+1. 创建新类继承基础功能
+2. 实现必需的方法
+3. 在 `NWChemLanguageServer.__init__` 中注册
+4. 在 `_register_handlers` 中添加 LSP 处理器
+
+## 来源列表 (Source List)
+
+- `raw/assets/architecture.md`
+- `raw/assets/README.md`
+- `raw/assets/nwchem_lsp/server.py`

--- a/wiki/synthesis/NWChem_DSL_Reference.md
+++ b/wiki/synthesis/NWChem_DSL_Reference.md
@@ -1,0 +1,184 @@
+# NWChem DSL Reference (NWChem 领域特定语言参考)
+
+> 创建日期：2026-06-12
+> 最后更新：2026-06-12
+> 覆盖来源：3
+
+## 核心论点 (Core Thesis)
+
+NWChem 输入文件是一种领域特定语言（DSL），用于描述量子化学计算。本参考提供了完整的语法结构。
+
+## 输入文件结构 (Input File Structure)
+
+```nwchem
+# 1. 计算标识
+start <project_name>
+
+# 2. 标题
+title "<calculation_title>"
+
+# 3. 电荷（可选）
+charge <integer>
+
+# 4. 内存设置（可选）
+memory total <n> gb
+
+# 5. 几何结构（必需）
+geometry [units <unit>] [options]
+  <element> <x> <y> <z>
+  ...
+end
+
+# 6. 基组（必需）
+basis [spherical|cartesian]
+  <element> library <basis_set>
+  * library <basis_set>
+end
+
+# 7. 赝势（可选）
+ecp
+  <element> library <ecp_name>
+end
+
+# 8. 理论方法配置
+scf|dft|mp2|ccsd
+  <method_options>
+end
+
+# 9. 任务（必需）
+task <theory> <operation>
+```
+
+## 顶层关键词 (Top-Level Keywords)
+
+### 计算控制 (Calculation Control)
+- `start <name>` - 指定重启文件名
+- `restart <name>` - 从之前的计算重启
+- `title "<string>"` - 设置计算标题
+- `charge <n>` - 设置分子电荷
+- `echo ["<string>"]` - 输出字符串
+
+### 资源设置 (Resource Settings)
+- `memory total <n> gb` - 设置内存限制
+- `memory stack <n> mb` - 设置栈内存
+- `memory heap <n> mb` - 设置堆内存
+- `permanent_dir <path>` - 永久目录
+- `scratch_dir <path>` - 临时目录
+
+### 部分定义 (Section Definitions)
+- `geometry` - 几何结构
+- `basis` - 基组
+- `ecp` - 有效核势
+- `scf` - SCF 配置
+- `dft` - DFT 配置
+- `mp2` - MP2 配置
+- `ccsd` - CCSD 配置
+- `task` - 执行任务
+
+## 部分语法 (Section Syntax)
+
+### Geometry 部分
+```nwchem
+geometry [units angstroms|bohr|...] [autosym|noautoz] [center|nocenter]
+  <element> <x> <y> <z>
+  ...
+end
+```
+
+### Basis 部分
+```nwchem
+basis [spherical|cartesian]
+  <element> library <basis_set>
+  * library <basis_set>  # 所有元素
+end
+```
+
+### DFT 部分
+```nwchem
+dft
+  xc <functional>
+  grid <coarse|medium|fine|xfine|ultrafine>
+  convergence energy <value>
+  iterations <n>
+end
+```
+
+### SCF 部分
+```nwchem
+scf
+  [singlet|doublet|triplet|quartet|quintet]
+  [rhf|uhf|rohf]
+  thresh <value>
+  maxiter <n>
+end
+```
+
+### MP2 部分
+```nwchem
+mp2
+  freeze [atomic|<n>]
+  [ri|cd]
+  [tight]
+end
+```
+
+### CCSD 部分
+```nwchem
+ccsd
+  freeze [atomic|<n>]
+  thresh <value>
+  maxiter <n>
+end
+```
+
+### Task 命令
+```nwchem
+task <theory> <operation>
+
+# 理论：scf, dft, mp2, ccsd, ccsd(t), mcscf, semi, rimp2
+# 操作：energy, optimize, gradient, frequencies, hessian, dynamics, property, saddle
+```
+
+## 语法约定 (Syntax Conventions)
+
+1. **大小写不敏感** - 关键词不区分大小写
+2. **注释** - `#` 开始单行注释
+3. **字符串** - 使用双引号
+4. **结束标记** - 部分块以 `end` 结束
+5. **行续** - 使用反斜杠 `\` 续行
+
+## 完整示例 (Complete Example)
+
+```nwchem
+start water_dft
+
+title "Water molecule DFT/B3LYP optimization"
+
+charge 0
+memory total 2 gb
+
+geometry units angstroms autosym
+  O  0.000000  0.000000  0.000000
+  H  0.000000  0.790000  0.580000
+  H  0.000000 -0.790000  0.580000
+end
+
+basis spherical
+  * library 6-31G*
+end
+
+dft
+  xc b3lyp
+  grid fine
+  convergence energy 1e-8
+  iterations 100
+end
+
+task dft optimize
+```
+
+## 来源列表 (Source List)
+
+- `raw/assets/README.md`
+- `raw/assets/keywords_data.py`
+- `raw/assets/water_dft.nw`

--- a/wiki/synthesis/Parser_API.md
+++ b/wiki/synthesis/Parser_API.md
@@ -1,0 +1,177 @@
+# Parser API (解析器 API)
+
+> 创建日期：2026-06-12
+> 最后更新：2026-06-12
+> 覆盖来源：2
+
+## 核心论点 (Core Thesis)
+
+`NwchemParser` 是 nwchem-lsp 的核心解析组件，提供 NWChem 输入文件的完整语法分析能力。
+
+## 类定义 (Class Definition)
+
+```python
+class NwchemParser:
+    def __init__(self, source: str)
+```
+
+## 关键词集合 (Keyword Sets)
+
+### SECTION_KEYWORDS
+需要 `end` 关键字闭合的部分：
+
+```
+geometry, basis, scf, dft, mp2, ccsd, ccsd(t), ecp, so, tce,
+mcscf, selci, hessian, vib, property, rt_tddft, pspw, band,
+paw, ofpw, bq, cons
+```
+
+### TOP_LEVEL_KEYWORDS
+顶层命令：
+
+```
+start, restart, title, echo, set, unset, stop, task, charge,
+memory, permanent_dir, scratch_dir, print
+```
+
+## 主要方法 (Main Methods)
+
+### get_context()
+```python
+def get_context(self, line_number: int, column: int) -> ParseContext
+```
+
+获取指定位置的解析上下文。
+
+**返回**: `ParseContext` 包含：
+- `line_number` - 行号
+- `column` - 列号
+- `current_section` - 当前部分名称
+- `section_stack` - 部分层栈
+- `line_content` - 行内容
+- `word_at_cursor` - 光标处的词
+- `is_in_block` - 是否在部分块内
+
+### get_completion_context()
+```python
+def get_completion_context(self, line_number: int, column: int) -> Dict[str, Any]
+```
+
+获取补全上下文信息。
+
+**返回**:
+- `type` - 补全类型（top_level, geometry, basis, dft 等）
+- `section` - 当前部分
+- `word` - 当前单词
+- `line` - 行内容
+- `in_block` - 是否在块内
+
+### get_section_at_line()
+```python
+def get_section_at_line(self, line_number: int) -> Optional[str]
+```
+
+获取指定行号所在的部分名称。
+
+### get_all_sections()
+```python
+def get_all_sections(self) -> List[str]
+```
+
+获取所有部分名称列表。
+
+### get_section_content()
+```python
+def get_section_content(self, section_name: str) -> List[NWchemSection]
+```
+
+获取指定部分的所有实例。
+
+### is_valid_syntax()
+```python
+def is_valid_syntax(self) -> Tuple[bool, List[Tuple[int, str]]]
+```
+
+检查输入文件语法是否有效。
+
+**返回**: `(is_valid, errors)`
+- `is_valid` - 布尔值，是否有效
+- `errors` - 错误列表，每个为 `(line_number, message)`
+
+### parse()
+```python
+def parse(self) -> list[Any]
+```
+
+解析并返回所有部分作为块列表。
+
+### validate()
+```python
+def validate(self) -> list[dict[str, Any]]
+```
+
+验证并返回错误字典列表。
+
+## 数据结构 (Data Structures)
+
+### ParseContext
+```python
+@dataclass
+class ParseContext:
+    line_number: int
+    column: int
+    current_section: Optional[str]
+    section_stack: List[str]
+    line_content: str
+    word_at_cursor: str
+    is_in_block: bool
+```
+
+### NWchemSection
+```python
+@dataclass
+class NWchemSection:
+    name: str
+    start_line: int
+    end_line: Optional[int]
+    keywords: List[str]
+    content: List[str]
+    line_start: int = 0
+```
+
+## 使用示例 (Usage Examples)
+
+### 基本解析
+```python
+from nwchem_lsp.parser.nwchem_parser import NwchemParser
+
+source = """
+geometry units angstroms
+  O 0.0 0.0 0.0
+  H 0.0 0.8 0.6
+end
+"""
+
+parser = NwchemParser(source)
+context = parser.get_context(1, 0)
+print(context.current_section)  # "geometry"
+```
+
+### 语法验证
+```python
+is_valid, errors = parser.is_valid_syntax()
+if not is_valid:
+    for line, message in errors:
+        print(f"Line {line}: {message}")
+```
+
+### 获取补全上下文
+```python
+ctx = parser.get_completion_context(2, 10)
+print(ctx["type"])  # "geometry"
+```
+
+## 来源列表 (Source List)
+
+- `raw/assets/nwchem_parser.py`
+- `raw/assets/architecture.md`


### PR DESCRIPTION
Adds Karpathy-style LLM Wiki with raw/ + wiki/ structure for NWChem domain knowledge.

## Summary

- Created  with source evidence files (docs, source code, examples)
- Created  with 22 pages across entities/, concepts/, and synthesis/
- Added  navigation hub and  change log
- Added  wiki structure specification

## Wiki Structure

### Entity Pages (13)
- NWChem, Geometry_Section, Basis_Set, DFT, Task_Operation
- SCF, MP2, CCSD, ECP, Chemical_Elements, XC_Functional
- LSP_Server, Diagnostic_System

### Concept Pages (5)
- Quantum_Chemistry_Methods, Basis_Set_Selection
- Geometry_Input_Formats, Convergence_Control, Spin_and_Multiplicity

### Synthesis Pages (4)
- NWChem_DSL_Reference, Diagnostics_Catalog
- Feature_Providers_API, Parser_API

## Features

- Bilingual format (Chinese headings, English terms)
- Obsidian-style [[Wiki_Link]] cross-references
- Source citations linking to raw/ files
- Karpathy-style raw/ evidence + wiki/ synthesis separation