### PR TITLE
Package nwchem for pip and pluggable skill export

### DIFF
--- a/.github/workflows/testpypi-release.yml
+++ b/.github/workflows/testpypi-release.yml
@@ -1,0 +1,118 @@
+name: TestPyPI release
+
+on:
+  push:
+    tags:
+      - "testpypi-v*"
+  workflow_dispatch:
+    inputs:
+      publish_to_testpypi:
+        description: "Publish the built artifacts to TestPyPI"
+        required: true
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  build:
+    name: Build artifacts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up Node.js
+        if: ${{ hashFiles('package.json') != '' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Set up Rust
+        if: ${{ hashFiles('Cargo.toml') != '' }}
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Check tag version
+        if: ${{ startsWith(github.ref, 'refs/tags/testpypi-v') }}
+        run: |
+          python - "${GITHUB_REF_NAME#testpypi-v}" <<'PY'
+          from pathlib import Path
+          import re
+          import sys
+          import tomllib
+
+          expected = sys.argv[1]
+          data = tomllib.loads(Path("pyproject.toml").read_text())
+          actual = (
+              data.get("project", {}).get("version")
+              or data.get("tool", {}).get("poetry", {}).get("version")
+          )
+          if actual is None and Path("setup.py").exists():
+              match = re.search(
+                  r"version\s*=\s*['\"]([^'\"]+)['\"]",
+                  Path("setup.py").read_text(),
+              )
+              actual = match.group(1) if match else None
+          if actual != expected:
+              raise SystemExit(
+                  f"tag version {expected!r} does not match package version {actual!r}"
+              )
+          PY
+
+      - name: Build artifacts
+        run: scripts/build-testpypi-artifacts.sh
+
+      - name: Upload dist artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/*
+
+  publish:
+    name: Publish to TestPyPI
+    needs: build
+    if: >-
+      ${{
+        startsWith(github.ref, 'refs/tags/testpypi-v')
+        || (github.event_name == 'workflow_dispatch'
+            && inputs.publish_to_testpypi)
+      }}
+    runs-on: ubuntu-latest
+    environment: testpypi
+    env:
+      TEST_PYPI_API_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }}
+    steps:
+      - name: Download dist artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+
+      - name: Publish to TestPyPI with token secret
+        if: ${{ env.TEST_PYPI_API_TOKEN != '' }}
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          packages-dir: dist/
+          password: ${{ env.TEST_PYPI_API_TOKEN }}
+          skip-existing: true
+          attestations: false
+
+      - name: Publish to TestPyPI with trusted publishing
+        if: ${{ env.TEST_PYPI_API_TOKEN == '' }}
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          packages-dir: dist/
+          skip-existing: true
+          attestations: false

--- a/docs/testpypi-release.md
+++ b/docs/testpypi-release.md
@@ -1,0 +1,64 @@
+# TestPyPI release workflow
+
+This repository publishes prerelease artifacts to TestPyPI only. Do not use this
+workflow for production PyPI releases.
+
+## Local build
+
+```bash
+scripts/build-testpypi-artifacts.sh
+```
+
+The build script writes `dist/`, runs package-specific build steps, validates the
+wheel and sdist with `twine check`, and verifies that the pluggable `skill/`
+metadata is present in the distribution artifacts. CIF repositories use the
+committed JavaScript bundle by default; set `CIF_REBUILD_JS=1` to refresh it
+before building.
+
+## Local TestPyPI upload
+
+Create a TestPyPI API token outside the repository, then run:
+
+```bash
+export TWINE_USERNAME=__token__
+export TWINE_PASSWORD='pypi-...'
+scripts/upload-testpypi.sh
+```
+
+The script defaults to `https://test.pypi.org/legacy/`. Override
+`TWINE_REPOSITORY_URL` only for a compatible private index.
+
+## GitHub tag release
+
+The workflow `.github/workflows/testpypi-release.yml` builds on every
+`testpypi-v*` tag. The tag version must match the package metadata.
+
+For the current prerelease:
+
+```bash
+git tag testpypi-v0.5.1rc1
+git push origin testpypi-v0.5.1rc1
+```
+
+The workflow can publish with either:
+
+- `TEST_PYPI_API_TOKEN` repository secret, using a TestPyPI token; or
+- TestPyPI Trusted Publishing configured for this repository, the
+  `testpypi-release.yml` workflow, and the `testpypi` GitHub environment.
+
+Manual runs are supported from the GitHub Actions tab. Leave
+`publish_to_testpypi=false` for build-only validation, or set it to `true` to
+publish.
+
+## Test install
+
+After publishing:
+
+```bash
+python -m venv /tmp/nwchem-lsp-testpypi
+/tmp/nwchem-lsp-testpypi/bin/python -m pip install --upgrade pip
+/tmp/nwchem-lsp-testpypi/bin/pip install \
+  --index-url https://test.pypi.org/simple/ \
+  --extra-index-url https://pypi.org/simple/ \
+  nwchem-lsp==0.5.1rc1
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nwchem-lsp"
-version = "0.5.0"
+version = "0.5.1rc1"
 description = "Language Server Protocol for NWChem input files (.nw, .nwinp)"
 readme = "README.md"
 license = {text = "MIT"}
@@ -30,6 +30,11 @@ dev = [
 
 [project.scripts]
 nwchem-lsp = "nwchem_lsp.server:main"
+nwchem-lsp-tool = "nwchem_lsp.tool:main"
+
+
+[tool.hatch.build.force-include]
+"skill" = "skill"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/nwchem_lsp"]

--- a/scripts/build-testpypi-artifacts.sh
+++ b/scripts/build-testpypi-artifacts.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+cd "$ROOT_DIR"
+
+rm -rf dist
+mkdir -p dist
+
+if [[ -f pyproject.toml ]] && grep -q 'build-backend = "maturin"' pyproject.toml; then
+  export CARGO_BUILD_JOBS="${CARGO_BUILD_JOBS:-2}"
+  uvx maturin build --release --out dist
+  uvx maturin sdist --out dist
+else
+  if [[ -f package.json && -d server/src && -d src/cif_lsp ]]; then
+    if [[ "${CIF_REBUILD_JS:-0}" != "1" \
+      && -s src/cif_lsp/js/cifLspTool.cjs \
+      && -s src/cif_lsp/js/server.cjs ]]; then
+      echo "Using existing bundled CIF JavaScript files."
+    else
+    npm ci --ignore-scripts
+    npm ci --prefix client
+    npm ci --prefix server
+    npm run compile
+    mkdir -p src/cif_lsp/js
+    npx --yes esbuild server/out/cifLspTool.js \
+      --bundle \
+      --platform=node \
+      --format=cjs \
+      --outfile=src/cif_lsp/js/cifLspTool.cjs
+    npx --yes esbuild server/out/server.js \
+      --bundle \
+      --platform=node \
+      --format=cjs \
+      --banner:js='#!/usr/bin/env node' \
+      --outfile=src/cif_lsp/js/server.cjs
+    chmod 755 src/cif_lsp/js/cifLspTool.cjs
+    fi
+  fi
+  uvx --from build python -m build --outdir dist
+fi
+
+uvx twine check dist/*
+
+"${PYTHON:-python3}" - <<'PY'
+from pathlib import Path
+import sys
+import tarfile
+import zipfile
+
+dist = Path("dist")
+wheels = sorted(dist.glob("*.whl"))
+sdists = sorted(dist.glob("*.tar.gz"))
+if not wheels or not sdists:
+    raise SystemExit("dist must contain at least one wheel and one sdist")
+
+for wheel in wheels:
+    with zipfile.ZipFile(wheel) as archive:
+        names = archive.namelist()
+    has_skill = any(name.endswith("skill/skill.yaml") for name in names)
+    has_embedded_skill_cli = any(
+        name.endswith(".data/scripts/lammps-lsp-tool")
+        or name.endswith("/lammps-lsp-tool")
+        for name in names
+    )
+    if not has_skill and not has_embedded_skill_cli:
+        raise SystemExit(f"{wheel} does not expose skill metadata")
+
+for sdist in sdists:
+    with tarfile.open(sdist) as archive:
+        names = archive.getnames()
+    if not any(name.endswith("/skill/skill.yaml") for name in names):
+        raise SystemExit(f"{sdist} does not include skill/skill.yaml")
+
+print("dist artifact checks passed", file=sys.stderr)
+PY

--- a/scripts/upload-testpypi.sh
+++ b/scripts/upload-testpypi.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+cd "$ROOT_DIR"
+
+if ! compgen -G "dist/*" >/dev/null; then
+  scripts/build-testpypi-artifacts.sh
+fi
+
+if [[ "${TWINE_USERNAME:-}" == "" || "${TWINE_PASSWORD:-}" == "" ]]; then
+  cat >&2 <<'EOF'
+Missing local TestPyPI credentials.
+
+Use a TestPyPI API token:
+  export TWINE_USERNAME=__token__
+  export TWINE_PASSWORD='pypi-...'
+
+GitHub Actions can publish without local credentials when TestPyPI Trusted
+Publishing is configured for .github/workflows/testpypi-release.yml.
+EOF
+  exit 2
+fi
+
+uvx twine upload \
+  --repository-url "${TWINE_REPOSITORY_URL:-https://test.pypi.org/legacy/}" \
+  "$@" \
+  dist/*

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: nwchem
+description: "NWChem input preflight for generated .nw and .nwinp files."
+---
+
+# NWChem LSP Skill
+
+Use this skill when preparing, repairing, or reviewing NWChem input files before a run. It provides an installable language server and an agent-facing CLI that reports machine-readable diagnostics.
+
+## Scope
+
+- Input patterns: *.nw, *.nwinp
+- Server command: `nwchem-lsp`
+- Agent CLI: `nwchem-lsp-tool`
+- Diagnostic contract: `DiagnosticEnvelope/v1`
+
+## Installing the checker
+
+```bash
+pip install nwchem-lsp
+```
+
+This installs the `nwchem-lsp` language server and the `nwchem-lsp-tool` agent CLI from the `nwchem-lsp` Python package.
+
+## Useful inspection commands
+
+```bash
+nwchem-lsp-tool capabilities
+nwchem-lsp-tool skill-spec --format json
+nwchem-lsp-tool skill-export --output ./skill
+nwchem-lsp-tool check <input-file-or-dir> --format json
+nwchem-lsp-tool context <input-file-or-dir> --line 0 --character 0 --format json
+nwchem-lsp-tool hover <input-file-or-dir> --line 0 --character 0 --format json
+nwchem-lsp-tool complete <input-file-or-dir> --line 0 --character 0 --format json
+nwchem-lsp-tool symbols <input-file-or-dir> --format json
+nwchem-lsp-tool fix <input-file-or-dir> --line 0 --character 0 --format json
+```
+
+`fix` is advisory and must be treated as a preview. Do not blindly apply a repair without preserving the user's scientific intent.
+
+## Validation gate
+
+Before saying generated inputs are ready, run:
+
+```bash
+nwchem-lsp-tool check <input-file-or-dir> --format json --fail-on-blocking
+```
+
+Report `commands`, `files_checked`, `tool_available`, `diagnostics`, `blocking_findings`, `readiness`, and `reason`.
+
+## Repair rules
+
+1. Validate first and identify the smallest blocking issue.
+2. Fix syntax or schema errors with minimal edits.
+3. Preserve scientific settings unless the user explicitly asks to redesign them.
+4. Re-run the checker after every edit.
+5. Separate syntax, schema, semantic, and runtime-log diagnostics in the final report.

--- a/skill/references/README.md
+++ b/skill/references/README.md
@@ -1,0 +1,3 @@
+# NWChem LSP Skill References
+
+This directory is reserved for small examples, rule notes, and templates that are safe to ship with the Python package. Keep large manuals and generated indexes in the LSP package proper, not in the pluggable skill artifact.

--- a/skill/skill.yaml
+++ b/skill/skill.yaml
@@ -1,0 +1,31 @@
+schema: scientific-lsp-skill/v1
+name: nwchem
+software: nwchem
+display_name: NWChem
+description: NWChem input preflight for generated .nw and .nwinp files.
+package:
+  name: nwchem-lsp
+  install: pip install nwchem-lsp
+entrypoints:
+  server: nwchem-lsp
+  tool: nwchem-lsp-tool
+file_patterns:
+  - *.nw
+  - *.nwinp
+operations:
+  - capabilities
+  - check
+  - context
+  - complete
+  - hover
+  - symbols
+  - fix
+diagnostic_contract: DiagnosticEnvelope/v1
+blocking_policy:
+  mode: warning-only
+  description: Use --fail-on-blocking when generated inputs must be launch-ready.
+source_provenance:
+  -
+    kind: official_docs
+    label: NWChem documentation
+    url: https://nwchemgit.github.io/

--- a/skill/skill.yaml
+++ b/skill/skill.yaml
@@ -10,8 +10,8 @@ entrypoints:
   server: nwchem-lsp
   tool: nwchem-lsp-tool
 file_patterns:
-  - *.nw
-  - *.nwinp
+  - "*.nw"
+  - "*.nwinp"
 operations:
   - capabilities
   - check

--- a/src/nwchem_lsp/skill_export.py
+++ b/src/nwchem_lsp/skill_export.py
@@ -1,0 +1,194 @@
+"""Export the bundled pluggable skill specification."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+SKILL_SPEC_JSON = (
+    '{"schema":"scientific-lsp-skill/v1","name":"nwchem","software":"nwchem","dis'
+    'play_name":"NWChem","description":"NWChem input preflight for generated .nw '
+    'and .nwinp files.","package":{"name":"nwchem-lsp","install":"pip install nwc'
+    'hem-lsp"},"entrypoints":{"server":"nwchem-lsp","tool":"nwchem-lsp-tool"},"fi'
+    'le_patterns":["*.nw","*.nwinp"],"operations":["capabilities","check","contex'
+    't","complete","hover","symbols","fix"],"diagnostic_contract":"DiagnosticEnve'
+    'lope/v1","blocking_policy":{"mode":"warning-only","description":"Use --fail-'
+    'on-blocking when generated inputs must be launch-ready."},"source_provenance'
+    '":[{"kind":"official_docs","label":"NWChem documentation","url":"https://nwc'
+    'hemgit.github.io/"}]}'
+)
+
+SKILL_SPEC: dict[str, Any] = json.loads(SKILL_SPEC_JSON)
+
+SKILL_MD_LINES = [
+    '---',
+    'name: nwchem',
+    'description: "NWChem input preflight for generated .nw and .nwinp files."',
+    '---',
+    '',
+    '# NWChem LSP Skill',
+    '',
+    (
+        'Use this skill when preparing, repairing, or reviewing NWChem input files be'
+        'fore a run. It provides an installable language server and an agent-facing C'
+        'LI that reports machine-readable diagnostics.'
+    ),
+    '',
+    '## Scope',
+    '',
+    '- Input patterns: *.nw, *.nwinp',
+    '- Server command: `nwchem-lsp`',
+    '- Agent CLI: `nwchem-lsp-tool`',
+    '- Diagnostic contract: `DiagnosticEnvelope/v1`',
+    '',
+    '## Installing the checker',
+    '',
+    '```bash',
+    'pip install nwchem-lsp',
+    '```',
+    '',
+    (
+        'This installs the `nwchem-lsp` language server and the `nwchem-lsp-tool` age'
+        'nt CLI from the `nwchem-lsp` Python package.'
+    ),
+    '',
+    '## Useful inspection commands',
+    '',
+    '```bash',
+    'nwchem-lsp-tool capabilities',
+    'nwchem-lsp-tool skill-spec --format json',
+    'nwchem-lsp-tool skill-export --output ./skill',
+    'nwchem-lsp-tool check <input-file-or-dir> --format json',
+    (
+        'nwchem-lsp-tool context <input-file-or-dir> --line 0 --character 0 --format '
+        'json'
+    ),
+    (
+        'nwchem-lsp-tool hover <input-file-or-dir> --line 0 --character 0 --format js'
+        'on'
+    ),
+    (
+        'nwchem-lsp-tool complete <input-file-or-dir> --line 0 --character 0 --format'
+        ' json'
+    ),
+    'nwchem-lsp-tool symbols <input-file-or-dir> --format json',
+    'nwchem-lsp-tool fix <input-file-or-dir> --line 0 --character 0 --format json',
+    '```',
+    '',
+    (
+        '`fix` is advisory and must be treated as a preview. Do not blindly apply a r'
+        "epair without preserving the user's scientific intent."
+    ),
+    '',
+    '## Validation gate',
+    '',
+    'Before saying generated inputs are ready, run:',
+    '',
+    '```bash',
+    'nwchem-lsp-tool check <input-file-or-dir> --format json --fail-on-blocking',
+    '```',
+    '',
+    (
+        'Report `commands`, `files_checked`, `tool_available`, `diagnostics`, `blocki'
+        'ng_findings`, `readiness`, and `reason`.'
+    ),
+    '',
+    '## Repair rules',
+    '',
+    '1. Validate first and identify the smallest blocking issue.',
+    '2. Fix syntax or schema errors with minimal edits.',
+    (
+        '3. Preserve scientific settings unless the user explicitly asks to redesign '
+        'them.'
+    ),
+    '4. Re-run the checker after every edit.',
+    (
+        '5. Separate syntax, schema, semantic, and runtime-log diagnostics in the fin'
+        'al report.'
+    ),
+]
+SKILL_MD = "\n".join(SKILL_MD_LINES) + "\n"
+
+REFERENCES_README_LINES = [
+    '# NWChem LSP Skill References',
+    '',
+    (
+        'This directory is reserved for small examples, rule notes, and templates tha'
+        't are safe to ship with the Python package. Keep large manuals and generated'
+        ' indexes in the LSP package proper, not in the pluggable skill artifact.'
+    ),
+]
+REFERENCES_README = "\n".join(REFERENCES_README_LINES) + "\n"
+
+
+def _yaml_scalar(value: object) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if value is None:
+        return "null"
+    if isinstance(value, (int, float)):
+        return str(value)
+    text = str(value)
+    if (
+        not text
+        or any(ch in text for ch in ":#[]{},&*?")
+        or text[0] in "-!@`"
+        or text.endswith(" ")
+        or "\n" in text
+    ):
+        return json.dumps(text, ensure_ascii=False)
+    return text
+
+
+def _to_yaml(value: object, indent: int = 0) -> str:
+    pad = " " * indent
+    if isinstance(value, dict):
+        lines: list[str] = []
+        for key, item in value.items():
+            if isinstance(item, (dict, list)):
+                lines.append(f"{pad}{key}:")
+                lines.append(_to_yaml(item, indent + 2))
+            else:
+                lines.append(f"{pad}{key}: {_yaml_scalar(item)}")
+        return "\n".join(lines)
+    if isinstance(value, list):
+        if not value:
+            return f"{pad}[]"
+        lines = []
+        for item in value:
+            if isinstance(item, (dict, list)):
+                lines.append(f"{pad}-")
+                lines.append(_to_yaml(item, indent + 2))
+            else:
+                lines.append(f"{pad}- {_yaml_scalar(item)}")
+        return "\n".join(lines)
+    return f"{pad}{_yaml_scalar(value)}"
+
+
+def skill_spec_text(output_format: str = "json") -> str:
+    if output_format == "json":
+        return json.dumps(SKILL_SPEC, indent=2, sort_keys=True, ensure_ascii=False)
+    if output_format == "yaml":
+        return _to_yaml(SKILL_SPEC) + "\n"
+    raise ValueError(f"unsupported skill spec format: {output_format}")
+
+
+def export_skill(output_dir: Path) -> dict[str, Any]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    references_dir = output_dir / "references"
+    references_dir.mkdir(exist_ok=True)
+    (output_dir / "skill.yaml").write_text(skill_spec_text("yaml"), encoding="utf-8")
+    (output_dir / "SKILL.md").write_text(SKILL_MD, encoding="utf-8")
+    (references_dir / "README.md").write_text(REFERENCES_README, encoding="utf-8")
+    return {
+        "ok": True,
+        "schema": SKILL_SPEC["schema"],
+        "name": SKILL_SPEC["name"],
+        "output_dir": str(output_dir),
+        "files": [
+            str(output_dir / "skill.yaml"),
+            str(output_dir / "SKILL.md"),
+            str(references_dir / "README.md"),
+        ],
+    }

--- a/src/nwchem_lsp/tool.py
+++ b/src/nwchem_lsp/tool.py
@@ -1,0 +1,225 @@
+"""Agent-facing CLI for Diagnostic Engine v1 operations."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from lsprotocol.types import Position
+
+from .features.completion import NwchemCompletionProvider
+from .features.diagnostic import NwchemDiagnosticProvider
+from .features.hover import NwchemHoverProvider
+from .features.symbols import NwchemSymbolProvider
+from .server import NWChemLanguageServer
+from .skill_export import SKILL_SPEC, export_skill, skill_spec_text
+
+SOFTWARE = "nwchem"
+
+
+def _file_type(path: Path) -> str:
+    if "." in path.name:
+        return path.suffix.lstrip(".").lower()
+    return path.name.lower()
+
+
+def _server() -> NWChemLanguageServer:
+    return NWChemLanguageServer()
+
+
+def _diagnostics(path: Path) -> list[dict[str, Any]]:
+    text = path.read_text(encoding="utf-8")
+    provider = NwchemDiagnosticProvider(_server())
+    return [provider.to_envelope(diag).to_dict() for diag in provider.get_diagnostics(text)]
+
+
+def _summary(diagnostics: list[dict[str, Any]]) -> dict[str, Any]:
+    blocking = [item for item in diagnostics if item.get("blocking")]
+    return {
+        "diagnostics": len(diagnostics),
+        "blocking": len(blocking),
+        "readiness": "blocked" if blocking else "ready",
+        "reason": (
+            "blocking diagnostics remain"
+            if blocking
+            else "no blocking diagnostics were reported"
+        ),
+    }
+
+
+def check_path(path: Path) -> dict[str, Any]:
+    diagnostics = _diagnostics(path)
+    summary = _summary(diagnostics)
+    return {
+        "schema": "DiagnosticEnvelope/v1",
+        "software": SOFTWARE,
+        "operation": "check",
+        "ok": not bool(summary["blocking"]),
+        "path": str(path),
+        "uri": path.resolve().as_uri(),
+        "file_type": _file_type(path),
+        "diagnostics": diagnostics,
+        "summary": summary,
+        "tool_available": True,
+        "files_checked": [str(path)],
+    }
+
+
+def _capabilities_payload() -> dict[str, Any]:
+    return {
+        "schema": "OpenQCLspCapabilities",
+        "version": 1,
+        "id": SKILL_SPEC["package"]["name"],
+        "software": SKILL_SPEC["software"],
+        "displayName": SKILL_SPEC["display_name"],
+        "executable": SKILL_SPEC["entrypoints"]["server"],
+        "filePatterns": SKILL_SPEC["file_patterns"],
+        "capabilities": [
+            "diagnostics",
+            "rich-diagnostics",
+            "completion",
+            "hover",
+            "symbols",
+            "fix-preview",
+            "pluggable-skill",
+        ],
+        "agentCli": {
+            "command": SKILL_SPEC["entrypoints"]["tool"],
+            "operations": SKILL_SPEC["operations"],
+            "jsonFormat": True,
+            "failOnBlocking": True,
+        },
+        "diagnosticContract": SKILL_SPEC["diagnostic_contract"],
+    }
+
+
+def _position(line: int, character: int) -> Position:
+    return Position(line=line, character=character)
+
+
+def _completion_item_to_dict(item: Any) -> dict[str, Any]:
+    return {
+        "label": getattr(item, "label", None),
+        "kind": int(getattr(item, "kind", 0) or 0),
+        "detail": getattr(item, "detail", None),
+        "documentation": getattr(item, "documentation", None),
+    }
+
+
+def _hover_to_dict(hover: Any) -> dict[str, Any]:
+    if hover is None:
+        return {"contents": None}
+    contents = getattr(hover, "contents", None)
+    return {
+        "contents": getattr(contents, "value", contents),
+        "kind": getattr(contents, "kind", None),
+    }
+
+
+def _symbol_to_dict(symbol: Any) -> dict[str, Any]:
+    return {
+        "name": getattr(symbol, "name", None),
+        "kind": int(getattr(symbol, "kind", 0) or 0),
+        "detail": getattr(symbol, "detail", None),
+        "range": {
+            "start": {
+                "line": symbol.range.start.line,
+                "character": symbol.range.start.character,
+            },
+            "end": {
+                "line": symbol.range.end.line,
+                "character": symbol.range.end.character,
+            },
+        },
+    }
+
+
+def _operation_payload(path: Path, operation: str, line: int, character: int) -> dict[str, Any]:
+    text = path.read_text(encoding="utf-8")
+    server = _server()
+    position = _position(line, character)
+    if operation == "complete":
+        items = NwchemCompletionProvider(server).get_completions(text, position)
+        return {
+            "software": SOFTWARE,
+            "operation": operation,
+            "path": str(path),
+            "items": [_completion_item_to_dict(item) for item in items],
+        }
+    if operation == "hover":
+        hover = NwchemHoverProvider(server).get_hover(text, position)
+        return {
+            "software": SOFTWARE,
+            "operation": operation,
+            "path": str(path),
+            "hover": _hover_to_dict(hover),
+        }
+    if operation == "symbols":
+        symbols = NwchemSymbolProvider(server).get_document_symbols(text)
+        return {
+            "software": SOFTWARE,
+            "operation": operation,
+            "path": str(path),
+            "symbols": [_symbol_to_dict(symbol) for symbol in symbols],
+        }
+    if operation == "fix":
+        return {
+            "software": SOFTWARE,
+            "operation": operation,
+            "path": str(path),
+            "fixes": [
+                item["fix_preview"]
+                for item in _diagnostics(path)
+                if item.get("fix_preview") is not None
+            ],
+            "advisory": True,
+        }
+    return {
+        "software": SOFTWARE,
+        "operation": operation,
+        "path": str(path),
+        "diagnostics": _diagnostics(path),
+        "summary": _summary(_diagnostics(path)),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="nwchem-lsp-tool")
+    subparsers = parser.add_subparsers(dest="operation", required=True)
+    capabilities = subparsers.add_parser("capabilities")
+    capabilities.add_argument("--format", choices=["json"], default="json")
+    skill_spec = subparsers.add_parser("skill-spec")
+    skill_spec.add_argument("--format", choices=["json", "yaml"], default="json")
+    skill_export = subparsers.add_parser("skill-export")
+    skill_export.add_argument("--output", type=Path, required=True)
+    for operation in ("check", "context", "complete", "hover", "symbols", "fix"):
+        sub = subparsers.add_parser(operation)
+        sub.add_argument("path", type=Path)
+        sub.add_argument("--format", choices=["json"], default="json")
+        sub.add_argument("--line", type=int, default=0)
+        sub.add_argument("--character", type=int, default=0)
+        if operation == "check":
+            sub.add_argument("--fail-on-blocking", action="store_true")
+    args = parser.parse_args(argv)
+    if args.operation == "capabilities":
+        print(json.dumps(_capabilities_payload(), indent=2, sort_keys=True))
+        return 0
+    if args.operation == "skill-spec":
+        print(skill_spec_text(args.format))
+        return 0
+    if args.operation == "skill-export":
+        print(json.dumps(export_skill(args.output), indent=2, sort_keys=True))
+        return 0
+    if args.operation == "check":
+        payload = check_path(args.path)
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return 1 if getattr(args, "fail_on_blocking", False) and not payload["ok"] else 0
+    payload = _operation_payload(args.path, args.operation, args.line, args.character)
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add a pluggable `skill/` manifest using `scientific-lsp-skill/v1`.
- Add `nwchem-lsp-tool skill-spec --format json|yaml` and `nwchem-lsp-tool skill-export --output <dir>`.
- Package the skill metadata with the wheel/sdist and bump to the next prerelease version.


## Verification
- `python -m compileall` / `cargo check` as applicable.
- Local wheel/sdist build completed.
- `twine check` passed for generated artifacts.
- Installed-wheel smoke passed for `--help`, `capabilities`, `skill-spec`, `skill-export`, and `check --format json`.

TestPyPI upload is intentionally not included in this PR because credentials are environment-provided and not stored in the repository.
