### PR TITLE
Release nwchem-lsp 0.5.0 with OIDC provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,68 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install project and release tooling
+        run: python -m pip install -e ".[dev]" build twine
+      - name: Run repository gate
+        run: make check
+      - name: Verify source metadata
+        run: python scripts/verify_release.py --tag "$GITHUB_REF_NAME"
+      - name: Build distributions once
+        run: python -m build
+      - name: Check distributions
+        run: python -m twine check dist/*
+      - name: Verify and smoke-test wheel
+        run: |
+          python scripts/verify_release.py --tag "$GITHUB_REF_NAME" --wheel dist/*.whl
+          bash scripts/smoke_wheel.sh dist/*.whl
+      - uses: actions/upload-artifact@v4
+        with:
+          name: release-distributions
+          path: dist/
+          if-no-files-found: error
+
+  publish-pypi:
+    needs: build-and-verify
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: release-distributions
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1c7041f130b6d4c3ae14794f19c4e
+
+  finalize-github-release:
+    needs: publish-pypi
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: release-distributions
+          path: dist/
+      - name: Create GitHub Release from the published artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "$GITHUB_REF_NAME" dist/* --verify-tag --generate-notes --title "$GITHUB_REF_NAME"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - `scripts/test.sh` uses `python3` via `PYTHON_BIN` for portable local/CI test runs.
 
-## [0.5.0] - 2026-03-05
+## [0.5.0] - 2026-07-16
 
 ### Added
+- Reproducible PyPI OIDC and GitHub Release workflow with source/wheel
+  verification and fresh-environment CLI smoke tests.
+- Stable `nwchem-lsp --help` and `--version` output for runtime probes.
+- Agent CLI `logs` operation for NWChem output fixtures.
 - **Folding Ranges**: Code folding support for NWChem sections
   - Fold/unfold geometry, basis, dft, and other sections
   - Visual indicators for collapsible regions

--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@
 
 Language Server Protocol implementation for NWChem quantum chemistry software.
 
+Current release: `0.5.0`.
+
+Release tags are built once, verified in a fresh virtual environment, and
+published to PyPI with OIDC Trusted Publishing through the protected `pypi`
+environment. The GitHub Release is created only after PyPI succeeds and reuses
+the exact same wheel and source distribution.
+
 ## Features
 
 ### Core LSP Features
@@ -54,6 +61,9 @@ pip install nwchem-lsp
 ### Command Line
 ```bash
 nwchem-lsp
+nwchem-lsp --help
+nwchem-lsp-tool capabilities --format json
+nwchem-lsp-tool logs calculation.out --format json
 ```
 
 ### Editor Configuration

--- a/lsp-capabilities.json
+++ b/lsp-capabilities.json
@@ -2,6 +2,9 @@
   "schema": "OpenQCLspCapabilities",
   "version": 1,
   "id": "nwchem-lsp",
+  "releaseVersion": "0.5.0",
+  "releaseTag": "v0.5.0",
+  "repository": "newtontech/nwchem-lsp",
   "software": "nwchem",
   "displayName": "NWChem",
   "languageId": "nwchem",
@@ -42,6 +45,7 @@
     "operations": [
       "capabilities",
       "check",
+      "logs",
       "context",
       "complete",
       "hover",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,15 @@ description = "Language Server Protocol for NWChem input files (.nw, .nwinp)"
 readme = "README.md"
 license = {text = "MIT"}
 requires-python = ">=3.9"
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
 dependencies = [
     "pygls>=1.2.0,<2.0.0",
     "lsprotocol>=2023.0.0",
@@ -19,10 +28,10 @@ dev = [
     "pytest>=7.0",
     "pytest-asyncio>=0.21.0",
     "pytest-cov>=4.0",
-    "black>=23.0",
-    "isort>=5.12.0",
-    "flake8>=6.0",
-    "mypy>=1.0",
+    "black==23.12.1",
+    "isort==5.13.2",
+    "flake8==7.0.0",
+    "mypy==1.8.0",
     "bandit>=1.7.0",
     "safety>=2.3.0",
     "pre-commit>=3.0",
@@ -34,6 +43,9 @@ nwchem-lsp-tool = "nwchem_lsp.tool:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/nwchem_lsp"]
+
+[tool.hatch.build.targets.wheel.force-include]
+"lsp-capabilities.json" = "nwchem_lsp/lsp-capabilities.json"
 
 [tool.black]
 line-length = 100
@@ -69,4 +81,3 @@ exclude_lines = [
     "pass",
     "..."
 ]
-

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -3,6 +3,17 @@ set -euo pipefail
 
 ran=0
 
+python_format_targets() {
+  local targets=""
+  [ -d src ] && targets="$targets src"
+  [ -d tests ] && targets="$targets tests"
+  if [ -z "${targets# }" ]; then
+    echo "."
+  else
+    echo "$targets"
+  fi
+}
+
 has_npm_script() {
   local script="$1"
   [ -f package.json ] || return 1

--- a/scripts/smoke_wheel.sh
+++ b/scripts/smoke_wheel.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+wheel="${1:?wheel path is required}"
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+venv="$(mktemp -d)"
+trap 'rm -rf "$venv"' EXIT
+
+python3 -m venv "$venv"
+"$venv/bin/python" -m pip install --quiet "$wheel"
+"$venv/bin/nwchem-lsp" --help
+"$venv/bin/nwchem-lsp" --version
+"$venv/bin/nwchem-lsp-tool" --help
+"$venv/bin/nwchem-lsp-tool" capabilities --format json
+"$venv/bin/nwchem-lsp-tool" check "$root/tests/fixtures/valid/water_scf.nw" --format json
+"$venv/bin/nwchem-lsp-tool" check "$root/tests/fixtures/invalid/missing_required.nw" --format json
+"$venv/bin/nwchem-lsp-tool" logs "$root/tests/fixtures/logs/scf_not_converged.out" --format json

--- a/scripts/verify_release.py
+++ b/scripts/verify_release.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Verify source and optional wheel metadata for an NWChem LSP release."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import zipfile
+from email.parser import Parser
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PACKAGE = "nwchem-lsp"
+
+
+def project_version() -> str:
+    text = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    match = re.search(r'^version = "([^"]+)"$', text, re.MULTILINE)
+    if match is None:
+        raise ValueError("project version is missing from pyproject.toml")
+    return match.group(1)
+
+
+def require(condition: bool, message: str, errors: list[str]) -> None:
+    if not condition:
+        errors.append(message)
+
+
+def verify_source(tag: str) -> tuple[str, list[str]]:
+    version = project_version()
+    errors: list[str] = []
+    manifest = json.loads((ROOT / "lsp-capabilities.json").read_text(encoding="utf-8"))
+    init_text = (ROOT / "src" / "nwchem_lsp" / "__init__.py").read_text(encoding="utf-8")
+    server_text = (ROOT / "src" / "nwchem_lsp" / "server.py").read_text(encoding="utf-8")
+
+    require(tag == f"v{version}", f"tag {tag!r} does not match version {version!r}", errors)
+    require(f'__version__ = "{version}"' in init_text, "package version is inconsistent", errors)
+    require(f"nwchem-lsp {version}" in server_text, "server version is inconsistent", errors)
+    require(manifest.get("releaseVersion") == version, "manifest version is inconsistent", errors)
+    require(manifest.get("releaseTag") == tag, "manifest tag is inconsistent", errors)
+    require(
+        manifest.get("repository") == "newtontech/nwchem-lsp",
+        "manifest repository is inconsistent",
+        errors,
+    )
+    require("logs" in manifest["agentCli"]["operations"], "logs operation is missing", errors)
+    return version, errors
+
+
+def verify_wheel(wheel: Path, version: str) -> list[str]:
+    errors: list[str] = []
+    with zipfile.ZipFile(wheel) as archive:
+        names = archive.namelist()
+        metadata_name = next((name for name in names if name.endswith(".dist-info/METADATA")), None)
+        entry_points_name = next(
+            (name for name in names if name.endswith(".dist-info/entry_points.txt")), None
+        )
+        manifest_name = "nwchem_lsp/lsp-capabilities.json"
+
+        require(metadata_name is not None, "wheel METADATA is missing", errors)
+        require(entry_points_name is not None, "wheel entry_points.txt is missing", errors)
+        require(manifest_name in names, "wheel capability manifest is missing", errors)
+        if metadata_name is not None:
+            metadata = Parser().parsestr(archive.read(metadata_name).decode("utf-8"))
+            require(metadata.get("Name") == PACKAGE, "wheel package name is inconsistent", errors)
+            require(metadata.get("Version") == version, "wheel version is inconsistent", errors)
+        if entry_points_name is not None:
+            entry_points = archive.read(entry_points_name).decode("utf-8")
+            for command in ("nwchem-lsp", "nwchem-lsp-tool"):
+                require(
+                    f"{command} =" in entry_points,
+                    f"wheel entry point {command} is missing",
+                    errors,
+                )
+        if manifest_name in names:
+            manifest = json.loads(archive.read(manifest_name))
+            require(
+                manifest.get("releaseVersion") == version,
+                "wheel capability version is inconsistent",
+                errors,
+            )
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("--wheel", type=Path)
+    args = parser.parse_args()
+
+    try:
+        version, errors = verify_source(args.tag)
+        if args.wheel is not None:
+            errors.extend(verify_wheel(args.wheel, version))
+    except (OSError, ValueError, KeyError, json.JSONDecodeError, zipfile.BadZipFile) as exc:
+        errors = [str(exc)]
+    if errors:
+        for error in errors:
+            print(f"release verification failed: {error}", file=sys.stderr)
+        return 1
+    print(f"release verification passed: {args.tag}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/nwchem_lsp/agent_operations.py
+++ b/src/nwchem_lsp/agent_operations.py
@@ -19,7 +19,7 @@ from typing import Any, Callable, Iterable
 
 from .rich_diagnostics import agent_check_payload
 
-OPERATIONS = ("check", "context", "complete", "hover", "symbols", "fix")
+OPERATIONS = ("check", "logs", "context", "complete", "hover", "symbols", "fix")
 _WORD_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_.$%+-]*")
 _SECTION_RE = re.compile(r"^\s*(?:&(?P<section>[A-Za-z][A-Za-z0-9_.$-]*)|\[(?P<bracket>[^\]]+)\])")
 _ASSIGNMENT_RE = re.compile(r"^\s*(?P<key>[A-Za-z_][A-Za-z0-9_.$%-]*)\s*(?:=|:|\s+)")

--- a/src/nwchem_lsp/server.py
+++ b/src/nwchem_lsp/server.py
@@ -9,6 +9,7 @@ Wiki
 
 from __future__ import annotations
 
+import argparse
 import json
 from typing import Any
 
@@ -322,8 +323,11 @@ def create_server() -> NWChemLanguageServer:
 server = create_server()
 
 
-def main() -> None:
-    """Main entry point for the language server."""
+def main(argv: list[str] | None = None) -> None:
+    """Run the language server or print its release metadata."""
+    parser = argparse.ArgumentParser(description="NWChem language server")
+    parser.add_argument("--version", action="version", version="nwchem-lsp 0.5.0")
+    parser.parse_args(argv)
     server.start_io()
 
 

--- a/src/nwchem_lsp/tool.py
+++ b/src/nwchem_lsp/tool.py
@@ -22,7 +22,9 @@ def _capabilities_payload() -> dict[str, Any]:
     for parent in Path(__file__).resolve().parents:
         manifest_path = parent / "lsp-capabilities.json"
         if manifest_path.exists():
-            return json.loads(manifest_path.read_text(encoding="utf-8"))
+            payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+            if isinstance(payload, dict):
+                return payload
     return {
         "schema": "OpenQCLspCapabilities",
         "version": 1,
@@ -209,6 +211,24 @@ def preflight_path(path: Path) -> dict[str, Any]:
     return with_capabilities(payload, "preflight")
 
 
+def logs_path(path: Path) -> dict[str, Any]:
+    """Parse an NWChem output log into the stable agent JSON envelope."""
+    from .features.agent_api import AgentAPIProvider
+
+    findings = AgentAPIProvider.parse_log(path.read_text(encoding="utf-8"))
+    return {
+        "uri": path.resolve().as_uri(),
+        "operation": "logs",
+        "ok": not any(item.get("severity") == "error" for item in findings),
+        "software": SOFTWARE,
+        "findings": findings,
+        "summary": {
+            "count": len(findings),
+            "errors": sum(item.get("severity") == "error" for item in findings),
+        },
+    }
+
+
 def manifest_path(path: Path | None = None) -> dict[str, Any]:
     """Return the fleet preflight manifest.
 
@@ -257,6 +277,7 @@ def main(argv: list[str] | None = None) -> int:
         "check",
         "preflight",
         "manifest",
+        "logs",
         "context",
         "complete",
         "hover",
@@ -302,6 +323,10 @@ def main(argv: list[str] | None = None) -> int:
         return 1 if getattr(args, "fail_on_blocking", False) and not payload["ok"] else 0
     if args.operation == "manifest":
         payload = manifest_path(getattr(args, "path", None))
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return 0
+    if args.operation == "logs":
+        payload = with_capabilities(logs_path(args.path), "logs")
         print(json.dumps(payload, indent=2, sort_keys=True))
         return 0
     payload = _operation_payload(args.path, args.operation, args.line, args.character)

--- a/tests/test_release_contract.py
+++ b/tests/test_release_contract.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import nwchem_lsp
+
+ROOT = Path(__file__).resolve().parents[1]
+RELEASE_VERSION = "0.5.0"
+
+
+def _project_version() -> str:
+    match = re.search(
+        r'^version = "([^"]+)"$',
+        (ROOT / "pyproject.toml").read_text(encoding="utf-8"),
+        re.MULTILINE,
+    )
+    assert match is not None
+    return match.group(1)
+
+
+def test_release_version_and_manifest_are_consistent() -> None:
+    manifest = json.loads((ROOT / "lsp-capabilities.json").read_text(encoding="utf-8"))
+
+    assert _project_version() == RELEASE_VERSION
+    assert nwchem_lsp.__version__ == RELEASE_VERSION
+    assert manifest["releaseVersion"] == RELEASE_VERSION
+    assert manifest["releaseTag"] == f"v{RELEASE_VERSION}"
+    assert manifest["repository"] == "newtontech/nwchem-lsp"
+    assert "logs" in manifest["agentCli"]["operations"]
+
+
+def test_release_workflow_uses_one_artifact_and_scoped_oidc() -> None:
+    workflow = (ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+
+    assert re.search(r"push:\s*\n\s+tags:\s*\[?\"v\*\"\]?", workflow)
+    assert "workflow_dispatch:" not in workflow
+    assert "cancel-in-progress: false" in workflow
+    assert "environment: pypi" in workflow
+    assert "id-token: write" in workflow
+    assert "pypa/gh-action-pypi-publish@" in workflow
+    assert "release-distributions" in workflow
+    assert "gh release create" in workflow
+    assert "scripts/verify_release.py" in workflow
+    assert "scripts/smoke_wheel.sh" in workflow
+
+
+def test_release_docs_and_smoke_cover_acceptance_surface() -> None:
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    changelog = (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+    smoke = (ROOT / "scripts" / "smoke_wheel.sh").read_text(encoding="utf-8")
+
+    assert f"Current release: `{RELEASE_VERSION}`" in readme
+    assert "Trusted Publishing" in readme
+    assert f"## [{RELEASE_VERSION}] - 2026-07-16" in changelog
+    for expected in (
+        "nwchem-lsp",
+        "nwchem-lsp-tool",
+        "--help",
+        " check ",
+        " logs ",
+        "tests/fixtures/valid/water_scf.nw",
+        "tests/fixtures/invalid/missing_required.nw",
+        "tests/fixtures/logs/scf_not_converged.out",
+    ):
+        assert expected in smoke
+
+
+def test_server_help_and_logs_cli() -> None:
+    help_result = subprocess.run(
+        [sys.executable, "-m", "nwchem_lsp.server", "--help"],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert help_result.returncode == 0
+    assert "NWChem language server" in help_result.stdout
+
+    logs_result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "nwchem_lsp.tool",
+            "logs",
+            "tests/fixtures/logs/scf_not_converged.out",
+            "--format",
+            "json",
+        ],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert logs_result.returncode == 0, logs_result.stdout + logs_result.stderr
+    payload = json.loads(logs_result.stdout)
+    assert payload["operation"] == "logs"
+    assert payload["findings"]
+
+
+def test_source_release_verifier_accepts_matching_tag() -> None:
+    result = subprocess.run(
+        [sys.executable, "scripts/verify_release.py", "--tag", f"v{RELEASE_VERSION}"],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
## Summary

- prepare nwchem-lsp 0.5.0 for first PyPI publication with protected OIDC trusted publishing
- build and verify one wheel and source distribution, then reuse them for PyPI and GitHub Release
- add stable server help and version probes plus the agent CLI logs operation
- embed versioned OpenQC capability metadata in the wheel
- verify valid, invalid, and runtime-log fixtures in a fresh virtual environment

## Tests

- make format executed; release Python files pass the pinned Black check and unrelated baseline-only rewrites were not kept
- make lint executed; the native script reports no configured Ruff command
- make typecheck: 32 source files clean with pinned mypy 1.8.0
- make test and make check: 700 passed, 4 existing collection warnings
- source and wheel release verifier passed for v0.5.0
- Twine checks passed for wheel and source distribution
- fresh-wheel server help/version, agent capabilities, valid, invalid, and logs smoke passed

No merge, tag, registry publish, GitHub Release, or runtime installation is performed by this PR. Human review and the protected pypi environment approval are required.

Fixes #108