### PR TITLE
fix: repair release workflow finalization

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           name: release-distributions
           path: dist/
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1c7041f130b6d4c3ae14794f19c4e
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
 
   finalize-github-release:
     needs: publish-pypi
@@ -58,6 +58,10 @@ jobs:
     permissions:
       contents: write
     steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0
       - uses: actions/download-artifact@v4
         with:
           name: release-distributions
@@ -65,4 +69,5 @@ jobs:
       - name: Create GitHub Release from the published artifacts
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
         run: gh release create "$GITHUB_REF_NAME" dist/* --verify-tag --generate-notes --title "$GITHUB_REF_NAME"

--- a/tests/test_release_contract.py
+++ b/tests/test_release_contract.py
@@ -41,7 +41,9 @@ def test_release_workflow_uses_one_artifact_and_scoped_oidc() -> None:
     assert "cancel-in-progress: false" in workflow
     assert "environment: pypi" in workflow
     assert "id-token: write" in workflow
-    assert "pypa/gh-action-pypi-publish@" in workflow
+    assert "pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b" in workflow
+    assert workflow.count("actions/checkout@v4") >= 2
+    assert "GH_REPO: ${{ github.repository }}" in workflow
     assert "release-distributions" in workflow
     assert "gh release create" in workflow
     assert "scripts/verify_release.py" in workflow


### PR DESCRIPTION
Fixes #110

## Summary

- replace the unavailable PyPI action revision with a valid immutable release pin
- checkout the exact tag before gh release --verify-tag and set GH_REPO explicitly
- retain the PyPI-before-GitHub release ordering and same verified artifacts

## Tests

- PYTHONPATH=$PWD/src python3 -m pytest tests/test_release_contract.py -q (5 passed)
- GitHub CI is authoritative for the full repository matrix